### PR TITLE
Fixed bug fortune

### DIFF
--- a/plugins/fortune.lua
+++ b/plugins/fortune.lua
@@ -1,7 +1,7 @@
  -- Requires that the "fortune" program is installed on your computer.
 
 local s = io.popen('fortune'):read('*all')
-if s:match('fortune: command not found') then
+if s:match('fortune: command not found') or ('fortune: not found') then
 	print('fortune is not installed on this computer.')
 	print('fortune.lua will not be enabled.')
 	return


### PR DESCRIPTION
Fixed bug fortune:
For message: "fortune: not found"

Before:
![image](https://cloud.githubusercontent.com/assets/5731176/12377707/9123d256-bd05-11e5-954e-c9c554508fcc.png)

and after:
![image](https://cloud.githubusercontent.com/assets/5731176/12377709/b0fb1f80-bd05-11e5-937c-41932272dc1e.png)

