### PR TITLE
FIX Bug Shell

### DIFF
--- a/plugins/shell.lua
+++ b/plugins/shell.lua
@@ -9,6 +9,8 @@ local action = function(msg)
 	end
 
 	local input = msg.text:input()
+	input = input:gsub('—', '--')
+	
 	if not input then
 		sendReply(msg, 'Please specify a command to run.')
 		return


### PR DESCRIPTION
Bug: Converts two characters `--` (U+002D) to `—`
That makes it impossible to use command such as: `--help`
