### PR TITLE
Increase reliability of Wikipedia

### DIFF
--- a/plugins/wikipedia.lua
+++ b/plugins/wikipedia.lua
@@ -43,10 +43,11 @@ local action = function(msg)
 		return
 	end
 --
-	local url = URL.unescape(jdat.responseData.results[1].url)
+	local url = jdat.responseData.results[1].unescapedUrl
 	local title = jdat.responseData.results[1].titleNoFormatting:gsub(' %- Wikipedia, the free encyclopedia', '')
 
-	jstr, res = HTTPS.request(wurl .. URL.escape(title))
+	-- 'https://en.wikipedia.org/wiki/':len ≡ 30
+	jstr, res = HTTPS.request(wurl .. url:sub(31))
 	if res ~= 200 then
 		sendReply(msg, config.error.connection)
 		return

--- a/plugins/wikipedia.lua
+++ b/plugins/wikipedia.lua
@@ -72,7 +72,8 @@ local action = function(msg)
 	title = title:gsub('%(.+%)', '')
 	--local output = '[' .. title .. '](' .. url .. ')\n' .. text:gsub('%[.+]%','')
 	--local output = '*' .. title .. '*\n' .. text:gsub('%[.+]%','') .. '\n[Read more.](' .. url .. ')'
-	local output = text:gsub('%[.+%]',''):gsub(title, '*'..title..'*') .. '\n'
+	local esctitle = title:gsub("[%^$()%%.%[%]*+%-?]","%%%1")
+	local output = text:gsub('%[.+%]',''):gsub(esctitle, '*%1*') .. '\n'
 	if url:find('%(') then
 		output = output .. url:gsub('_', '\\_')
 	else


### PR DESCRIPTION
Pulls directly from the unescaped URL now and feeds that into `wurl` instead of the escaped title.