### PR TITLE
Explicit config

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,29 +35,29 @@ When you are ready to start the bot, run `./launch.sh`. To stop the bot, send "/
 
 Note that certain plugins, such as translate.lua and greetings.lua, will require privacy mode to be disabled. Additionally, some plugins may require or make use of various API keys:
 
- - bing.lua: [Bing Search API](http://datamarket.azure.com/dataset/bing/search) key (`bing_api_key`)
- - gImages.lua & youtube.lua: Google [API](http://console.developers.google.com) and [CSE](https://cse.google.com/cse) keys (`google_api_key`, `google_cse_key`)
- - weather.lua: [OpenWeatherMap](http://openweathermap.org) API key (`owm_api_key`)
- - lastfm.lua: [last.fm](http://last.fm/api) API key (`lastfm_api_key`)
- - bible.lua: [Biblia](http://api.biblia.com) API key (`biblia_api_key`)
- - cats.lua: [The Cat API](http://thecatapi.com) API key (optional) (`thecatapi_key`)
- - apod.lua: [NASA](http://api.nasa.gov) API key (`nasa_api_key`)
- - translate.lua: [Yandex](http://tech.yandex.com/keys/get) API key (`yandex_key`)
- - chatter.lua: [SimSimi](http://developer.simsimi.com/signUp) API key (`simsimi_key`)
+ - `bing.lua`: [Bing Search API](http://datamarket.azure.com/dataset/bing/search) key (`bing_api_key`)
+ - `gImages.lua` & `youtube.lua`: Google [API](http://console.developers.google.com) and [CSE](https://cse.google.com/cse) keys (`google_api_key`, `google_cse_key`)
+ - `weather.lua`: [OpenWeatherMap](http://openweathermap.org) API key (`owm_api_key`)
+ - `lastfm.lua`: [last.fm](http://last.fm/api) API key (`lastfm_api_key`)
+ - `bible.lua`: [Biblia](http://api.biblia.com) API key (`biblia_api_key`)
+ - `cats.lua`: [The Cat API](http://thecatapi.com) API key (optional) (`thecatapi_key`)
+ - `apod.lua`: [NASA](http://api.nasa.gov) API key (`nasa_api_key`)
+ - `translate.lua`: [Yandex](http://tech.yandex.com/keys/get) API key (`yandex_key`)
+ - `chatter.lua`: [SimSimi](http://developer.simsimi.com/signUp) API key (`simsimi_key`)
 
 * * *
 
 ## Control plugins
 Some plugins are designed to be used by the bot's owner. Here are some examples, how they're used, and what they do.
 
-| Plugin        | Command    | Function                                           |
-|:--------------|:-----------|:---------------------------------------------------|
-| control.lua   | /reload    | Reloads all plugins and configuration.             |
-|               | /halt      | Shuts down the bot after saving the database.      |
-|               | /script    | Runs a list a bot commands, separated by newlines. |
-| blacklist.lua | /blacklist | Blocks people from using the bot.                  |
-| shell.lua     | /run       | Executes shell commands on the host system.        |
-| luarun.lua    | /lua       | Executes Lua commands in the bot's environment.    |
+| Plugin          | Command    | Function                                           |
+|:----------------|:-----------|:---------------------------------------------------|
+| `control.lua`   | /reload    | Reloads all plugins and configuration.             |
+|                 | /halt      | Shuts down the bot after saving the database.      |
+|                 | /script    | Runs a list a bot commands, separated by newlines. |
+| `blacklist.lua` | /blacklist | Blocks people from using the bot.                  |
+| `shell.lua`     | /run       | Executes shell commands on the host system.        |
+| `luarun.lua`    | /lua       | Executes Lua commands in the bot's environment.    |
 
 * * *
 
@@ -68,7 +68,7 @@ To get started, run `./tg-install.sh`. Note that this script is written for Ubun
 
 Once the installation is finished, enable the `administration` plugin in your config file. **The administration plugin must be loaded before the `about` and `blacklist` plugins.** You may have reason to change the default TCP port (4567); if that is the case, remember to change it in `tg-launch.sh` as well. Run `./tg-launch.sh` in a separate screen/tmux window. You'll have to enter your phone number and go through the login process the first time. The script is set to restart tg after two seconds, so you'll need to Ctrl+C after exiting.
 
-While tg is running, you may start/reload otouto with administration.lua enabled, and have access to a wide variety of administrative commands and automata. The administration "database" is stored in `administration.json`. To start using otouto to administrate a group (note that you must be the owner (or an administrator)), send `/gadd` to that group. For a list of commands, use `/ahelp`. Below I'll describe various functions now available to you.
+While tg is running, you may start/reload otouto with `administration.lua` enabled, and have access to a wide variety of administrative commands and automata. The administration "database" is stored in `administration.json`. To start using otouto to administrate a group (note that you must be the owner (or an administrator)), send `/gadd` to that group. For a list of commands, use `/ahelp`. Below I'll describe various functions now available to you.
 
 | Command     | Function                                        | Privilege | Internal? |
 |:------------|:------------------------------------------------|:----------|:----------|
@@ -151,46 +151,46 @@ Additionally, antiflood can be configured to automatically ban a user after he h
 
 ## List of plugins
 
-| Plugin              | Command                       | Function                                                | Aliases |
-|:--------------------|:------------------------------|:--------------------------------------------------------|:--------|
-| help.lua            | /help [command]               | Returns a list of commands or command-specific help.       | /h   |
-| about.lua           | /about                        | Returns the about text as configured in config.lua.               |
-| ping.lua            | /ping                         | The simplest plugin ever!                                         |
-| echo.lua            | /echo ‹text›                  | Repeats a string of text.                                         |
-| bing.lua            | /bing ‹query›                 | Returns Bing web results.                                  | /g   |
-| gImages.lua         | /images ‹query›               | Returns a Google image result.                             | /i   |
-| gMaps.lua           | /location ‹query›             | Returns location data from Google Maps.                    | /loc |
-| youtube.lua         | /youtube ‹query›              | Returns the top video result from YouTube.                 | /yt  |
-| wikipedia.lua       | /wikipedia ‹query›            | Returns the summary of a Wikipedia article.                | /w   |
-| lastfm.lua          | /np [username]                | Returns the song you are currently listening to.                  |
-| lastfm.lua          | /fmset [username]             | Sets your username for /np. /fmset -- will delete it.             |
-| hackernews.lua      | /hackernews                   | Returns the latest posts from Hacker News.                 | /hn  |
-| imdb.lua            | /imdb ‹query›                 | Returns film information from IMDb.                               |
-| hearthstone.lua     | /hearthstone ‹query›          | Returns data for Hearthstone cards matching the query.     | /hs  |
-| calc.lua            | /calc ‹expression›            | Returns conversions and solutions to math expressions.            |
-| bible.lua           | /bible ‹reference›            | Returns a Bible verse.                                     | /b   |
-| urbandictionary.lua | /urban ‹query›                | Returns the top definition from Urban Dictionary.          | /ud  |
-| time.lua            | /time ‹query›                 | Returns the time, date, and a timezone for a location.            |
-| weather.lua         | /weather ‹query›              | Returns current weather conditions for a given location.          |
-| nick.lua            | /nick ‹nickname›              | Set your nickname. /nick - will delete it.                        |
-| whoami.lua          | /whoami                       | Returns user and chat info for you or the replied-to user. | /who |
-| eightball.lua       | /8ball                        | Returns an answer from a magic 8-ball.                            |
-| dice.lua            | /roll ‹nDr›                   | Returns RNG dice rolls. Uses D&D notation.                        |
-| reddit.lua          | /reddit [r/subreddit ¦ query] | Returns the top results from a subreddit, query, or r/all. | /r   |
-| xkcd.lua            | /xkcd [query]                 | Returns an xkcd strip and its alt text.                           |
-| slap.lua            | /slap ‹target›                | Gives someone a slap (or worse).                                  |
-| commit.lua          | /commit                       | Returns a commit message from whatthecommit.com.                  |
-| fortune.lua         | /fortune                      | Returns a UNIX fortune.                                           |
-| pun.lua             | /pun                          | Returns a pun.                                                    |
-| pokedex.lua         | /pokedex ‹query›              | Returns a Pokedex entry.                                   | /dex |
-| currency.lua        | /cash [amount] ‹cur› to ‹cur› | Converts one currency to another.                                 |
-| cats.lua            | /cat                          | Returns a cat picture.                                            |
-| reactions.lua       | /reactions                    | Returns a list of emoticons which can be posted by the bot.       |
-| apod.lua            | /apod [date]                  | Returns the NASA Astronomy Picture of the Day.                    |
-| dilbert.lua         | /dilbert [date]               | Returns a Dilbert strip.                                          |
-| patterns.lua        | /s/‹from›/‹to›/               | Search-and-replace using Lua patterns.                            |
-| me.lua              | /me                           | Returns user-specific data stored by the bot.                     |
-| remind.lua          | /remind <duration> <message>  | Reminds a user of something after a duration of minutes.          |
+| Plugin                | Command                       | Function                                                | Aliases |
+|:----------------------|:------------------------------|:--------------------------------------------------------|:--------|
+| `help.lua`            | /help [command]               | Returns a list of commands or command-specific help.       | /h   |
+| `about.lua`           | /about                        | Returns the about text as configured in config.lua.               |
+| `ping.lua`            | /ping                         | The simplest plugin ever!                                         |
+| `echo.lua`            | /echo ‹text›                  | Repeats a string of text.                                         |
+| `bing.lua`            | /bing ‹query›                 | Returns Bing web results.                                  | /g   |
+| `gImages.lua`         | /images ‹query›               | Returns a Google image result.                             | /i   |
+| `gMaps.lua`           | /location ‹query›             | Returns location data from Google Maps.                    | /loc |
+| `youtube.lua`         | /youtube ‹query›              | Returns the top video result from YouTube.                 | /yt  |
+| `wikipedia.lua`       | /wikipedia ‹query›            | Returns the summary of a Wikipedia article.                | /w   |
+| `lastfm.lua`          | /np [username]                | Returns the song you are currently listening to.                  |
+| `lastfm.lua`          | /fmset [username]             | Sets your username for /np. /fmset -- will delete it.             |
+| `hackernews.lua`      | /hackernews                   | Returns the latest posts from Hacker News.                 | /hn  |
+| `imdb.lua`            | /imdb ‹query›                 | Returns film information from IMDb.                               |
+| `hearthstone.lua`     | /hearthstone ‹query›          | Returns data for Hearthstone cards matching the query.     | /hs  |
+| `calc.lua`            | /calc ‹expression›            | Returns conversions and solutions to math expressions.            |
+| `bible.lua`           | /bible ‹reference›            | Returns a Bible verse.                                     | /b   |
+| `urbandictionary.lua` | /urban ‹query›                | Returns the top definition from Urban Dictionary.          | /ud  |
+| `time.lua`            | /time ‹query›                 | Returns the time, date, and a timezone for a location.            |
+| `weather.lua`         | /weather ‹query›              | Returns current weather conditions for a given location.          |
+| `nick.lua`            | /nick ‹nickname›              | Set your nickname. /nick - will delete it.                        |
+| `whoami.lua`          | /whoami                       | Returns user and chat info for you or the replied-to user. | /who |
+| `eightball.lua`       | /8ball                        | Returns an answer from a magic 8-ball.                            |
+| `dice.lua`            | /roll ‹nDr›                   | Returns RNG dice rolls. Uses D&D notation.                        |
+| `reddit.lua`          | /reddit [r/subreddit ¦ query] | Returns the top results from a subreddit, query, or r/all. | /r   |
+| `xkcd.lua`            | /xkcd [query]                 | Returns an xkcd strip and its alt text.                           |
+| `slap.lua`            | /slap ‹target›                | Gives someone a slap (or worse).                                  |
+| `commit.lua`          | /commit                       | Returns a commit message from whatthecommit.com.                  |
+| `fortune.lua`         | /fortune                      | Returns a UNIX fortune.                                           |
+| `pun.lua`             | /pun                          | Returns a pun.                                                    |
+| `pokedex.lua`         | /pokedex ‹query›              | Returns a Pokedex entry.                                   | /dex |
+| `currency.lua`        | /cash [amount] ‹cur› to ‹cur› | Converts one currency to another.                                 |
+| `cats.lua`            | /cat                          | Returns a cat picture.                                            |
+| `reactions.lua`       | /reactions                    | Returns a list of emoticons which can be posted by the bot.       |
+| `apod.lua`            | /apod [date]                  | Returns the NASA Astronomy Picture of the Day.                    |
+| `dilbert.lua`         | /dilbert [date]               | Returns a Dilbert strip.                                          |
+| `patterns.lua`        | /s/‹from›/‹to›/               | Search-and-replace using Lua patterns.                            |
+| `me.lua`              | /me                           | Returns user-specific data stored by the bot.                     |
+| `remind.lua`          | /remind <duration> <message>  | Reminds a user of something after a duration of minutes.          |
 
 * * *
 

--- a/bot.lua
+++ b/bot.lua
@@ -6,18 +6,16 @@ local utilities -- Load miscellaneous and cross-plugin functions.
 
 bot.version = '3.8'
 
-function bot:init() -- The function run when the bot is started or reloaded.
+function bot:init(config) -- The function run when the bot is started or reloaded.
 
 	bindings = require('bindings')
 	utilities = require('utilities')
 
-	self.config = require('config') -- Load configuration file.
-
 	assert(
-		self.config.bot_api_key and self.config.bot_api_key ~= '',
-		'You did not set your bot token in config.lua!'
+		config.bot_api_key and config.bot_api_key ~= '',
+		'You did not set your bot token in the config!'
 	)
-	self.BASE_URL = 'https://api.telegram.org/bot' .. self.config.bot_api_key .. '/'
+	self.BASE_URL = 'https://api.telegram.org/bot' .. config.bot_api_key .. '/'
 
 	-- Fetch bot information. Try until it succeeds.
 	repeat
@@ -35,10 +33,10 @@ function bot:init() -- The function run when the bot is started or reloaded.
 	self.database.users[tostring(self.info.id)] = self.info
 
 	self.plugins = {} -- Load plugins.
-	for _,v in ipairs(self.config.plugins) do
+	for _,v in ipairs(config.plugins) do
 		local p = require('plugins.'..v)
 		table.insert(self.plugins, p)
-		if p.init then p.init(self) end
+		if p.init then p.init(self, config) end
 	end
 
 	print('@' .. self.info.username .. ', AKA ' .. self.info.first_name ..' ('..self.info.id..')')
@@ -49,7 +47,7 @@ function bot:init() -- The function run when the bot is started or reloaded.
 
 end
 
-function bot:on_msg_receive(msg) -- The fn run whenever a message is received.
+function bot:on_msg_receive(msg, config) -- The fn run whenever a message is received.
 
 	-- Cache user info for those involved.
 	utilities.create_user_entry(self, msg.from)
@@ -72,11 +70,11 @@ function bot:on_msg_receive(msg) -- The fn run whenever a message is received.
 		for _,w in pairs(v.triggers) do
 			if string.match(msg.text:lower(), w) then
 				local success, result = pcall(function()
-					return v.action(self, msg)
+					return v.action(self, msg, config)
 				end)
 				if not success then
 					utilities.send_reply(self, msg, 'Sorry, an unexpected error occurred.')
-					utilities.handle_exception(self, result, msg.from.id .. ': ' .. msg.text)
+					utilities.handle_exception(self, result, msg.from.id .. ': ' .. msg.text, config)
 					return
 				end
 				-- If the action returns a table, make that table the new msg.
@@ -93,7 +91,8 @@ function bot:on_msg_receive(msg) -- The fn run whenever a message is received.
 end
 
 function bot:run()
-	bot.init(self) -- Actually start the script. Run the bot_init function.
+	local config = require('config') -- Load configuration file.
+	bot.init(self, config) -- Actually start the script.
 
 	while self.is_started do -- Start a loop while the bot should be running.
 
@@ -102,7 +101,7 @@ function bot:run()
 			for _,v in ipairs(res.result) do -- Go through every new message.
 				self.last_update = v.update_id
 				if v.message then
-					bot.on_msg_receive(self, v.message)
+					bot.on_msg_receive(self, v.message, config)
 				end
 			end
 		else
@@ -116,7 +115,7 @@ function bot:run()
 				if v.cron then -- Call each plugin's cron function, if it has one.
 					local result, err = pcall(function() v.cron(self) end)
 					if not result then
-						utilities.handle_exception(self, err, 'CRON: ' .. i)
+						utilities.handle_exception(self, err, 'CRON: ' .. i, config)
 					end
 				end
 			end

--- a/bot.lua
+++ b/bot.lua
@@ -61,14 +61,14 @@ function bot:on_msg_receive(msg, config) -- The fn run whenever a message is rec
 
 	msg = utilities.enrich_message(msg)
 
-	if msg.text:match('^'..utilities.CMD_PAT..'start .+') then
-		msg.text = utilities.CMD_PAT .. utilities.input(msg.text)
+	if msg.text:match('^'..config.cmd_pat..'start .+') then
+		msg.text = config.cmd_pat .. utilities.input(msg.text)
 		msg.text_lower = msg.text:lower()
 	end
 
 	for _,v in ipairs(self.plugins) do
 		for _,w in pairs(v.triggers) do
-			if string.match(msg.text:lower(), w) then
+			if string.match(msg.text_lower, w) then
 				local success, result = pcall(function()
 					return v.action(self, msg, config)
 				end)
@@ -90,8 +90,7 @@ function bot:on_msg_receive(msg, config) -- The fn run whenever a message is rec
 
 end
 
-function bot:run()
-	local config = require('config') -- Load configuration file.
+function bot:run(config)
 	bot.init(self, config) -- Actually start the script.
 
 	while self.is_started do -- Start a loop while the bot should be running.
@@ -113,7 +112,7 @@ function bot:run()
 			utilities.save_data(self.info.username..'.db', self.database) -- Save the database.
 			for i,v in ipairs(self.plugins) do
 				if v.cron then -- Call each plugin's cron function, if it has one.
-					local result, err = pcall(function() v.cron(self) end)
+					local result, err = pcall(function() v.cron(self, config) end)
 					if not result then
 						utilities.handle_exception(self, err, 'CRON: ' .. i, config)
 					end

--- a/bot.lua
+++ b/bot.lua
@@ -61,8 +61,8 @@ function bot:on_msg_receive(msg, config) -- The fn run whenever a message is rec
 
 	msg = utilities.enrich_message(msg)
 
-	if msg.text:match('^/start .+') then
-		msg.text = '/' .. utilities.input(msg.text)
+	if msg.text:match('^'..utilities.CMD_PAT..'start .+') then
+		msg.text = utilities.CMD_PAT .. utilities.input(msg.text)
 		msg.text_lower = msg.text:lower()
 	end
 

--- a/config.lua
+++ b/config.lua
@@ -18,6 +18,8 @@ I am otouto, the plugin-wielding, multipurpose Telegram bot.
 
 Send /help to get started.
 	]],
+	-- The symbol that starts a command. Usually noted as '/' in documentation.
+	cmd_pat = '/',
 
 	-- https://datamarket.azure.com/dataset/bing/search
 	bing_api_key = '',

--- a/main.lua
+++ b/main.lua
@@ -1,5 +1,6 @@
 local bot = require('bot')
 
 local instance = {}
+local config = require('config')
 
-return bot.run(instance)
+return bot.run(instance, config)

--- a/plugins/about.lua
+++ b/plugins/about.lua
@@ -10,13 +10,13 @@ about.triggers = {
 	''
 }
 
-function about:action(msg)
+function about:action(msg, config)
 
 	-- Filthy hack, but here is where we'll stop forwarded messages from hitting
 	-- other plugins.
 	if msg.forward_from then return end
 
-	local output = self.config.about_text .. '\nBased on otouto v'..bot.version..' by topkecleon.'
+	local output = config.about_text .. '\nBased on otouto v'..bot.version..' by topkecleon.'
 
 	if (msg.new_chat_participant and msg.new_chat_participant.id == self.info.id)
 		or msg.text_lower:match('^/about')

--- a/plugins/about.lua
+++ b/plugins/about.lua
@@ -19,9 +19,9 @@ function about:action(msg, config)
 	local output = config.about_text .. '\nBased on otouto v'..bot.version..' by topkecleon.'
 
 	if (msg.new_chat_participant and msg.new_chat_participant.id == self.info.id)
-		or msg.text_lower:match('^'..utilities.CMD_PAT..'about')
-		or msg.text_lower:match('^'..utilities.CMD_PAT..'about@'..self.info.username:lower())
-	or msg.text_lower:match('^'..utilities.CMD_PAT..'start') then
+		or msg.text_lower:match('^'..config.cmd_pat..'about')
+		or msg.text_lower:match('^'..config.cmd_pat..'about@'..self.info.username:lower())
+	or msg.text_lower:match('^'..config.cmd_pat..'start') then
 		utilities.send_message(self, msg.chat.id, output, true)
 		return
 	end

--- a/plugins/about.lua
+++ b/plugins/about.lua
@@ -19,9 +19,9 @@ function about:action(msg, config)
 	local output = config.about_text .. '\nBased on otouto v'..bot.version..' by topkecleon.'
 
 	if (msg.new_chat_participant and msg.new_chat_participant.id == self.info.id)
-		or msg.text_lower:match('^/about')
-		or msg.text_lower:match('^/about@'..self.info.username:lower())
-	or msg.text_lower:match('^/start') then
+		or msg.text_lower:match('^'..utilities.CMD_PAT..'about')
+		or msg.text_lower:match('^'..utilities.CMD_PAT..'about@'..self.info.username:lower())
+	or msg.text_lower:match('^'..utilities.CMD_PAT..'start') then
 		utilities.send_message(self, msg.chat.id, output, true)
 		return
 	end

--- a/plugins/administration.lua
+++ b/plugins/administration.lua
@@ -75,8 +75,8 @@ administration.flags = {
 		name = 'unlisted',
 		desc = 'Removes this group from the group listing.',
 		short = 'This group is unlisted.',
-		enabled = 'This group is no longer listed in /groups.',
-		disabled = 'This group is now listed in /groups.'
+		enabled = 'This group is no longer listed in '..utilities.CMD_PAT..'groups.',
+		disabled = 'This group is now listed in '..utilities.CMD_PAT..'groups.'
 	},
 	[2] = {
 		name = 'antisquig',
@@ -105,7 +105,7 @@ administration.flags = {
 		name = 'antiflood',
 		desc = 'Prevents flooding by rate-limiting messages per user.',
 		short = 'This group automatically removes users who flood.',
-		enabled = 'Users will now be removed automatically for excessive messages. Use /antiflood to configure limits.',
+		enabled = 'Users will now be removed automatically for excessive messages. Use '..utilities.CMD_PAT..'antiflood to configure limits.',
 		disabled = 'Users will no longer be removed automatically for excessive messages.',
 		kicked = 'You were automatically kicked from GROUPNAME for flooding.'
 	},
@@ -237,7 +237,7 @@ function administration:get_desc(chat_id)
 	if modstring ~= '' then
 		table.insert(t, '*Moderators:*\n' .. utilities.trim(modstring))
 	end
-	table.insert(t, 'Run /ahelp@' .. self.info.username .. ' for a list of commands.')
+	table.insert(t, 'Run '..utilities.CMD_PAT..'ahelp@' .. self.info.username .. ' for a list of commands.')
 	return table.concat(t, '\n\n')
 
 end
@@ -250,7 +250,7 @@ function administration:update_desc(chat)
 		local gov = self.database.users[tostring(group.governor)]
 		desc = desc .. '\nGovernor: ' .. utilities.build_name(gov.first_name, gov.last_name) .. ' [' .. gov.id .. ']\n'
 	end
-	local s = '\n/desc@' .. self.info.username .. ' for more information.'
+	local s = '\n'..utilities.CMD_PAT..'desc@' .. self.info.username .. ' for more information.'
 	desc = desc:sub(1, 250-s:len()) .. s
 	drua.channel_set_about(chat, desc)
 end
@@ -521,11 +521,11 @@ function administration.init_command(self_, config)
 				local rank = administration.get_rank(self, msg.from.id, msg.chat.id, config)
 				local input = utilities.get_word(msg.text_lower, 2)
 				if input then
-					input = input:gsub('^/', '')
+					input = input:gsub('^'..utilities.CMD_PAT..'', '')
 					local doc
 					for _,action in ipairs(administration.commands) do
 						if action.keyword == input then
-							doc = '/' .. action.command:gsub('\\','') .. '\n' .. action.doc
+							doc = ''..utilities.CMD_PAT..'' .. action.command:gsub('\\','') .. '\n' .. action.doc
 							break
 						end
 					end
@@ -533,14 +533,14 @@ function administration.init_command(self_, config)
 						local output = '*Help for* _' .. input .. '_ :\n```\n' .. doc .. '\n```'
 						utilities.send_message(self, msg.chat.id, output, true, nil, true)
 					else
-						local output = 'Sorry, there is no help for that command.\n/ahelp@'..self.info.username
+						local output = 'Sorry, there is no help for that command.\n'..utilities.CMD_PAT..'ahelp@'..self.info.username
 						utilities.send_reply(self, msg, output)
 					end
 				else
 					local output = '*Commands for ' .. administration.ranks[rank] .. ':*\n'
 					for i = 1, rank do
 						for _, val in ipairs(self.admin_temp.help[i]) do
-							output = output .. '• /' .. val .. '\n'
+							output = output .. '• ' .. utilities.CMD_PAT .. val .. '\n'
 						end
 					end
 					output = output .. 'Arguments: <required> \\[optional]'
@@ -771,7 +771,7 @@ function administration.init_command(self_, config)
 			doc = 'Sets the group\'s rules. Rules will be automatically numbered. Separate rules with a new line. Markdown is supported. Pass "--" to delete the rules.',
 
 			action = function(self, msg, group, config)
-				local input = msg.text:match('^/setrules[@'..self.info.username..']*(.+)')
+				local input = msg.text:match('^'..utilities.CMD_PAT..'setrules[@'..self.info.username..']*(.+)')
 				if input == ' --' or input == ' ' .. utilities.char.em_dash then
 					group.rules = {}
 					utilities.send_reply(self, msg, 'The rules have been cleared.')
@@ -802,7 +802,7 @@ function administration.init_command(self_, config)
 
 			action = function(self, msg, group, config)
 				local input = utilities.input(msg.text)
-				local output = 'usage: `/changerule <i> <newrule>`'
+				local output = 'usage: `'..utilities.CMD_PAT..'changerule <i> <newrule>`'
 				if input then
 					local rule_num = tonumber(input:match('^%d+'))
 					local new_rule = utilities.input(input)
@@ -944,7 +944,7 @@ function administration.init_command(self_, config)
 
 			action = function(self, msg, group, config)
 				if not group.flags[5] then
-					utilities.send_message(self, msg.chat.id, 'antiflood is not enabled. Use `/flag 5` to enable it.', true, nil, true)
+					utilities.send_message(self, msg.chat.id, 'antiflood is not enabled. Use `'..utilities.CMD_PAT..'flag 5` to enable it.', true, nil, true)
 				else
 					if not group.antiflood then
 						group.antiflood = JSON.decode(JSON.encode(administration.antiflood))
@@ -963,7 +963,7 @@ function administration.init_command(self_, config)
 							output = '*' .. key:gsub('^%l', string.upper) .. '* messages are now worth *' .. val .. '* points.'
 						end
 					else
-						output = 'usage: `/antiflood <type> <i>`\nexample: `/antiflood text 5`\nUse this command to configure the point values for each message type. When a user reaches 100 points, he is kicked. The points are reset each minute. The current values are:\n'
+						output = 'usage: `'..utilities.CMD_PAT..'antiflood <type> <i>`\nexample: `'..utilities.CMD_PAT..'antiflood text 5`\nUse this command to configure the point values for each message type. When a user reaches 100 points, he is kicked. The points are reset each minute. The current values are:\n'
 						for k,v in pairs(group.antiflood) do
 							output = output .. '*'..k..':* `'..v..'`\n'
 						end
@@ -1389,6 +1389,6 @@ function administration:cron()
 end
 
 administration.command = 'groups'
-administration.doc = '`Returns a list of administrated groups.\nUse /ahelp for more administrative commands.`'
+administration.doc = '`Returns a list of administrated groups.\nUse '..utilities.CMD_PAT..'ahelp for more administrative commands.`'
 
 return administration

--- a/plugins/apod.lua
+++ b/plugins/apod.lua
@@ -9,12 +9,12 @@ local utilities = require('utilities')
 
 apod.command = 'apod [date]'
 apod.doc = [[```
-/apod [query]
+]]..utilities.CMD_PAT..[[apod [query]
 Returns the Astronomy Picture of the Day.
 If the query is a date, in the format YYYY-MM-DD, the APOD of that day is returned.
-/apodhd [query]
+]]..utilities.CMD_PAT..[[apodhd [query]
 Returns the image in HD, if available.
-/apodtext [query]
+]]..utilities.CMD_PAT..[[apodtext [query]
 Returns the explanation of the APOD.
 Source: nasa.gov
 ```]]
@@ -65,13 +65,13 @@ function apod:action(msg, config)
 
 	local img_url = jdat.url
 
-	if string.match(msg.text, '^/apodhd*') then
+	if string.match(msg.text, '^'..utilities.CMD_PAT..'apodhd*') then
 		img_url = jdat.hdurl or jdat.url
 	end
 
 	local output = date .. '[' .. jdat.title  .. '](' .. img_url .. ')'
 
-	if string.match(msg.text, '^/apodtext*') then
+	if string.match(msg.text, '^'..utilities.CMD_PAT..'apodtext*') then
 		output = output .. '\n' .. jdat.explanation
 		disable_page_preview = true
 	end

--- a/plugins/apod.lua
+++ b/plugins/apod.lua
@@ -8,20 +8,20 @@ local URL = require('socket.url')
 local utilities = require('utilities')
 
 apod.command = 'apod [date]'
-apod.doc = [[```
-]]..utilities.CMD_PAT..[[apod [query]
+
+function apod:init(config)
+	apod.triggers = utilities.triggers(self.info.username, config.cmd_pat)
+		:t('apod', true):t('apodhd', true):t('apodtext', true).table
+	apod.doc = [[```
+]]..config.cmd_pat..[[apod [query]
 Returns the Astronomy Picture of the Day.
 If the query is a date, in the format YYYY-MM-DD, the APOD of that day is returned.
-]]..utilities.CMD_PAT..[[apodhd [query]
+]]..config.cmd_pat..[[apodhd [query]
 Returns the image in HD, if available.
-]]..utilities.CMD_PAT..[[apodtext [query]
+]]..config.cmd_pat..[[apodtext [query]
 Returns the explanation of the APOD.
 Source: nasa.gov
 ```]]
-
-function apod:init()
-	apod.triggers = utilities.triggers(self.info.username)
-		:t('apod', true):t('apodhd', true):t('apodtext', true).table
 end
 
 function apod:action(msg, config)
@@ -65,13 +65,13 @@ function apod:action(msg, config)
 
 	local img_url = jdat.url
 
-	if string.match(msg.text, '^'..utilities.CMD_PAT..'apodhd*') then
+	if string.match(msg.text, '^'..config.cmd_pat..'apodhd*') then
 		img_url = jdat.hdurl or jdat.url
 	end
 
 	local output = date .. '[' .. jdat.title  .. '](' .. img_url .. ')'
 
-	if string.match(msg.text, '^'..utilities.CMD_PAT..'apodtext*') then
+	if string.match(msg.text, '^'..config.cmd_pat..'apodtext*') then
 		output = output .. '\n' .. jdat.explanation
 		disable_page_preview = true
 	end

--- a/plugins/apod.lua
+++ b/plugins/apod.lua
@@ -24,17 +24,17 @@ function apod:init()
 		:t('apod', true):t('apodhd', true):t('apodtext', true).table
 end
 
-function apod:action(msg)
+function apod:action(msg, config)
 
-	if not self.config.nasa_api_key then
-		self.config.nasa_api_key = 'DEMO_KEY'
+	if not config.nasa_api_key then
+		config.nasa_api_key = 'DEMO_KEY'
 	end
 
 	local input = utilities.input(msg.text)
 	local date = '*'
 	local disable_page_preview = false
 
-	local url = 'https://api.nasa.gov/planetary/apod?api_key=' .. self.config.nasa_api_key
+	local url = 'https://api.nasa.gov/planetary/apod?api_key=' .. config.nasa_api_key
 
 	if input then
 		if input:match('(%d+)%-(%d+)%-(%d+)$') then
@@ -52,14 +52,14 @@ function apod:action(msg)
 
 	local jstr, res = HTTPS.request(url)
 	if res ~= 200 then
-		utilities.send_reply(self, msg, self.config.errors.connection)
+		utilities.send_reply(self, msg, config.errors.connection)
 		return
 	end
 
 	local jdat = JSON.decode(jstr)
 
 	if jdat.error then
-		utilities.send_reply(msg, self.config.errors.results)
+		utilities.send_reply(self, msg, config.errors.results)
 		return
 	end
 

--- a/plugins/bandersnatch.lua
+++ b/plugins/bandersnatch.lua
@@ -5,7 +5,7 @@ local utilities = require('utilities')
 bandersnatch.command = 'bandersnatch'
 bandersnatch.doc = [[```
 Shun the frumious Bandersnatch.
-Alias: /bc
+Alias: ]]..utilities.CMD_PAT..[[bc
 ```]]
 
 function bandersnatch:init()

--- a/plugins/bandersnatch.lua
+++ b/plugins/bandersnatch.lua
@@ -3,13 +3,13 @@ local bandersnatch = {}
 local utilities = require('utilities')
 
 bandersnatch.command = 'bandersnatch'
-bandersnatch.doc = [[```
-Shun the frumious Bandersnatch.
-Alias: ]]..utilities.CMD_PAT..[[bc
-```]]
 
-function bandersnatch:init()
-	bandersnatch.triggers = utilities.triggers(self.info.username):t('bandersnatch'):t('bc').table
+function bandersnatch:init(config)
+	bandersnatch.triggers = utilities.triggers(self.info.username, config.cmd_pat):t('bandersnatch'):t('bc').table
+	bandersnatch.doc = [[```
+Shun the frumious Bandersnatch.
+Alias: ]]..config.cmd_pat..[[bc
+```]]
 end
 
 local fullnames = { "Wimbledon Tennismatch", "Rinkydink Curdlesnoot", "Butawhiteboy Cantbekhan", "Benadryl Claritin", "Bombadil Rivendell", "Wanda's Crotchfruit", "Biblical Concubine", "Syphilis Cankersore", "Buckminster Fullerene", "Bourgeoisie Capitalist" }

--- a/plugins/bible.lua
+++ b/plugins/bible.lua
@@ -11,15 +11,15 @@ function bible:init(config)
 		return
 	end
 
-	bible.triggers = utilities.triggers(self.info.username):t('bible', true):t('b', true).table
+	bible.triggers = utilities.triggers(self.info.username, config.cmd_pat):t('bible', true):t('b', true).table
+	bible.doc = [[```
+]]..config.cmd_pat..[[bible <reference>
+Returns a verse from the American Standard Version of the Bible, or an apocryphal verse from the King James Version. Results from biblia.com.
+Alias: ]]..config.cmd_pat..[[b
+```]]
 end
 
 bible.command = 'bible <reference>'
-bible.doc = [[```
-]]..utilities.CMD_PAT..[[bible <reference>
-Returns a verse from the American Standard Version of the Bible, or an apocryphal verse from the King James Version. Results from biblia.com.
-Alias: ]]..utilities.CMD_PAT..[[b
-```]]
 
 function bible:action(msg, config)
 

--- a/plugins/bible.lua
+++ b/plugins/bible.lua
@@ -4,8 +4,8 @@ local HTTP = require('socket.http')
 local URL = require('socket.url')
 local utilities = require('utilities')
 
-function bible:init()
-	if not self.config.biblia_api_key then
+function bible:init(config)
+	if not config.biblia_api_key then
 		print('Missing config value: biblia_api_key.')
 		print('bible.lua will not be enabled.')
 		return
@@ -21,7 +21,7 @@ Returns a verse from the American Standard Version of the Bible, or an apocrypha
 Alias: /b
 ```]]
 
-function bible:action(msg)
+function bible:action(msg, config)
 
 	local input = utilities.input(msg.text)
 	if not input then
@@ -29,17 +29,17 @@ function bible:action(msg)
 		return
 	end
 
-	local url = 'http://api.biblia.com/v1/bible/content/ASV.txt?key=' .. self.config.biblia_api_key .. '&passage=' .. URL.escape(input)
+	local url = 'http://api.biblia.com/v1/bible/content/ASV.txt?key=' .. config.biblia_api_key .. '&passage=' .. URL.escape(input)
 
 	local output, res = HTTP.request(url)
 
 	if not output or res ~= 200 or output:len() == 0 then
-		url = 'http://api.biblia.com/v1/bible/content/KJVAPOC.txt?key=' .. self.config.biblia_api_key .. '&passage=' .. URL.escape(input)
+		url = 'http://api.biblia.com/v1/bible/content/KJVAPOC.txt?key=' .. config.biblia_api_key .. '&passage=' .. URL.escape(input)
 		output, res = HTTP.request(url)
 	end
 
 	if not output or res ~= 200  or output:len() == 0 then
-		output = self.config.errors.results
+		output = config.errors.results
 	end
 
 	if output:len() > 4000 then

--- a/plugins/bible.lua
+++ b/plugins/bible.lua
@@ -16,9 +16,9 @@ end
 
 bible.command = 'bible <reference>'
 bible.doc = [[```
-/bible <reference>
+]]..utilities.CMD_PAT..[[bible <reference>
 Returns a verse from the American Standard Version of the Bible, or an apocryphal verse from the King James Version. Results from biblia.com.
-Alias: /b
+Alias: ]]..utilities.CMD_PAT..[[b
 ```]]
 
 function bible:action(msg, config)

--- a/plugins/blacklist.lua
+++ b/plugins/blacklist.lua
@@ -19,7 +19,7 @@ function blacklist:action(msg, config)
 
 	if self.database.blacklist[msg.from.id_str] then return end
 	if self.database.blacklist[msg.chat.id_str] then return end
-	if not msg.text:match('^/blacklist') then return true end
+	if not msg.text:match('^'..utilities.CMD_PAT..'blacklist') then return true end
 	if msg.from.id ~= config.admin then return end
 
 	local target = utilities.user_from_message(self, msg)

--- a/plugins/blacklist.lua
+++ b/plugins/blacklist.lua
@@ -19,7 +19,7 @@ function blacklist:action(msg, config)
 
 	if self.database.blacklist[msg.from.id_str] then return end
 	if self.database.blacklist[msg.chat.id_str] then return end
-	if not msg.text:match('^'..utilities.CMD_PAT..'blacklist') then return true end
+	if not msg.text:match('^'..config.cmd_pat..'blacklist') then return true end
 	if msg.from.id ~= config.admin then return end
 
 	local target = utilities.user_from_message(self, msg)

--- a/plugins/blacklist.lua
+++ b/plugins/blacklist.lua
@@ -15,12 +15,12 @@ blacklist.triggers = {
 	''
 }
 
-function blacklist:action(msg)
+function blacklist:action(msg, config)
 
 	if self.database.blacklist[msg.from.id_str] then return end
 	if self.database.blacklist[msg.chat.id_str] then return end
 	if not msg.text:match('^/blacklist') then return true end
-	if msg.from.id ~= self.config.admin then return end
+	if msg.from.id ~= config.admin then return end
 
 	local target = utilities.user_from_message(self, msg)
 	if target.err then

--- a/plugins/calc.lua
+++ b/plugins/calc.lua
@@ -5,13 +5,13 @@ local HTTPS = require('ssl.https')
 local utilities = require('utilities')
 
 calc.command = 'calc <expression>'
-calc.doc = [[```
-]]..utilities.CMD_PAT..[[calc <expression>
+
+function calc:init(config)
+	calc.triggers = utilities.triggers(self.info.username, config.cmd_pat):t('calc', true).table
+	calc.doc = [[```
+]]..config.cmd_pat..[[calc <expression>
 Returns solutions to mathematical expressions and conversions between common units. Results provided by mathjs.org.
 ```]]
-
-function calc:init()
-	calc.triggers = utilities.triggers(self.info.username):t('calc', true).table
 end
 
 function calc:action(msg, config)

--- a/plugins/calc.lua
+++ b/plugins/calc.lua
@@ -14,7 +14,7 @@ function calc:init()
 	calc.triggers = utilities.triggers(self.info.username):t('calc', true).table
 end
 
-function calc:action(msg)
+function calc:action(msg, config)
 
 	local input = utilities.input(msg.text)
 	if not input then
@@ -30,7 +30,7 @@ function calc:action(msg)
 
 	local output = HTTPS.request(url)
 	if not output then
-		utilities.send_reply(self, msg, self.config.errors.connection)
+		utilities.send_reply(self, msg, config.errors.connection)
 		return
 	end
 

--- a/plugins/calc.lua
+++ b/plugins/calc.lua
@@ -6,7 +6,7 @@ local utilities = require('utilities')
 
 calc.command = 'calc <expression>'
 calc.doc = [[```
-/calc <expression>
+]]..utilities.CMD_PAT..[[calc <expression>
 Returns solutions to mathematical expressions and conversions between common units. Results provided by mathjs.org.
 ```]]
 

--- a/plugins/cats.lua
+++ b/plugins/cats.lua
@@ -3,8 +3,8 @@ local cats = {}
 local HTTP = require('socket.http')
 local utilities = require('utilities')
 
-function cats:init()
-	if not self.config.thecatapi_key then
+function cats:init(config)
+	if not config.thecatapi_key then
 		print('Missing config value: thecatapi_key.')
 		print('cats.lua will be enabled, but there are more features with a key.')
 	end
@@ -15,16 +15,16 @@ end
 cats.command = 'cat'
 cats.doc = '`Returns a cat!`'
 
-function cats:action(msg)
+function cats:action(msg, config)
 
 	local url = 'http://thecatapi.com/api/images/get?format=html&type=jpg'
-	if self.config.thecatapi_key then
-		url = url .. '&api_key=' .. self.config.thecatapi_key
+	if config.thecatapi_key then
+		url = url .. '&api_key=' .. config.thecatapi_key
 	end
 
 	local str, res = HTTP.request(url)
 	if res ~= 200 then
-		utilities.send_reply(msg, self.config.errors.connection)
+		utilities.send_reply(self, msg, onfig.errors.connection)
 		return
 	end
 

--- a/plugins/cats.lua
+++ b/plugins/cats.lua
@@ -9,7 +9,7 @@ function cats:init(config)
 		print('cats.lua will be enabled, but there are more features with a key.')
 	end
 
-	cats.triggers = utilities.triggers(self.info.username):t('cat').table
+	cats.triggers = utilities.triggers(self.info.username, config.cmd_pat):t('cat').table
 end
 
 cats.command = 'cat'

--- a/plugins/chatter.lua
+++ b/plugins/chatter.lua
@@ -8,8 +8,8 @@ local JSON = require('dkjson')
 local bindings = require('bindings')
 local utilities = require('utilities')
 
-function chatter:init()
-	if not self.config.simsimi_key then
+function chatter:init(config)
+	if not config.simsimi_key then
 		print('Missing config value: simsimi_key.')
 		print('chatter.lua will not be enabled.')
 		return
@@ -22,7 +22,7 @@ end
 
 chatter.base_url = 'http://%sapi.simsimi.com/request.p?key=%s&lc=%s&ft=1.0&text=%s'
 
-function chatter:action(msg)
+function chatter:action(msg, config)
 
 	if msg.text == '' then return true end
 
@@ -47,17 +47,17 @@ function chatter:action(msg)
 
 	local sandbox = self.config.simsimi_trial and 'sandbox.' or ''
 
-	local url = chatter.base_url:format(sandbox, self.config.simsimi_key, self.config.lang, URL.escape(input))
+	local url = chatter.base_url:format(sandbox, config.simsimi_key, self.config.lang, URL.escape(input))
 
 	local jstr, res = HTTP.request(url)
 	if res ~= 200 then
-		utilities.send_message(self, msg.chat.id, self.config.errors.chatter_connection)
+		utilities.send_message(self, msg.chat.id, config.errors.chatter_connection)
 		return
 	end
 
 	local jdat = JSON.decode(jstr)
 	if not jdat.response or jdat.response:match('^I HAVE NO RESPONSE.') then
-		utilities.send_message(self, msg.chat.id, self.config.errors.chatter_response)
+		utilities.send_message(self, msg.chat.id, config.errors.chatter_response)
 		return
 	end
 	local output = jdat.response

--- a/plugins/chatter.lua
+++ b/plugins/chatter.lua
@@ -34,7 +34,7 @@ function chatter:action(msg, config)
 			--Uncomment the following line for Al Gore-like conversation.
 			--or (msg.reply_to_message and msg.reply_to_message.from.id == self.info.id)
 		)
-		or msg.text:match('^/')
+		or msg.text:match('^'..utilities.CMD_PAT)
 		or msg.text == ''
 	) then
 		return true

--- a/plugins/chatter.lua
+++ b/plugins/chatter.lua
@@ -6,7 +6,6 @@ local HTTP = require('socket.http')
 local URL = require('socket.url')
 local JSON = require('dkjson')
 local bindings = require('bindings')
-local utilities = require('utilities')
 
 function chatter:init(config)
 	if not config.simsimi_key then
@@ -34,7 +33,7 @@ function chatter:action(msg, config)
 			--Uncomment the following line for Al Gore-like conversation.
 			--or (msg.reply_to_message and msg.reply_to_message.from.id == self.info.id)
 		)
-		or msg.text:match('^'..utilities.CMD_PAT)
+		or msg.text:match('^'..config.CMD_PAT)
 		or msg.text == ''
 	) then
 		return true

--- a/plugins/commit.lua
+++ b/plugins/commit.lua
@@ -7,8 +7,8 @@ local utilities = require('utilities')
 commit.command = 'commit'
 commit.doc = '`Returns a commit message from whatthecommit.com.`'
 
-function commit:init()
-	commit.triggers = utilities.triggers(self.info.username):t('commit').table
+function commit:init(config)
+	commit.triggers = utilities.triggers(self.info.username, config.cmd_pat):t('commit').table
 end
 
 local commits = {

--- a/plugins/control.lua
+++ b/plugins/control.lua
@@ -8,9 +8,9 @@ function control:init()
 	table.insert(control.triggers, '^/script')
 end
 
-function control:action(msg)
+function control:action(msg, config)
 
-	if msg.from.id ~= self.config.admin then
+	if msg.from.id ~= config.admin then
 		return
 	end
 
@@ -21,11 +21,14 @@ function control:action(msg)
 			if pac:match('^plugins%.') then
 				package.loaded[pac] = nil
 			end
-			package.loaded['bindings'] = nil
-			package.loaded['utilities'] = nil
-			package.loaded['config'] = nil
 		end
-		bot.init(self)
+		package.loaded['bindings'] = nil
+		package.loaded['utilities'] = nil
+		package.loaded['config'] = nil
+		for k, v in pairs(require('config')) do
+			config[k] = v
+		end
+		bot.init(self, config)
 		utilities.send_reply(self, msg, 'Bot reloaded!')
 	elseif msg.text:match('^'..utilities.INVOCATION_PATTERN..'halt') then
 		self.is_started = false

--- a/plugins/control.lua
+++ b/plugins/control.lua
@@ -3,9 +3,12 @@ local control = {}
 local bot = require('bot')
 local utilities = require('utilities')
 
-function control:init()
-	control.triggers = utilities.triggers(self.info.username):t('reload'):t('halt').table
-	table.insert(control.triggers, '^'..utilities.CMD_PAT..'script')
+local cmd_pat -- Prevents the command from being uncallable.
+
+function control:init(config)
+	cmd_pat = config.cmd_pat
+	control.triggers = utilities.triggers(self.info.username, cmd_pat,
+		{'^'..cmd_pat..'script'}):t('reload', true):t('halt').table
 end
 
 function control:action(msg, config)
@@ -16,7 +19,7 @@ function control:action(msg, config)
 
 	if msg.date < os.time() - 1 then return end
 
-	if msg.text:match('^'..utilities.CMD_PAT..'reload') then
+	if msg.text_lower:match('^'..cmd_pat..'reload') then
 		for pac, _ in pairs(package.loaded) do
 			if pac:match('^plugins%.') then
 				package.loaded[pac] = nil
@@ -25,18 +28,18 @@ function control:action(msg, config)
 		package.loaded['bindings'] = nil
 		package.loaded['utilities'] = nil
 		package.loaded['config'] = nil
-		for k, v in pairs(require('config')) do
+		if msg.text_lower:match('%+config') then for k, v in pairs(require('config')) do
 			config[k] = v
-		end
+		end end
 		bot.init(self, config)
 		utilities.send_reply(self, msg, 'Bot reloaded!')
-	elseif msg.text:match('^'..utilities.CMD_PAT..'halt') then
+	elseif msg.text_lower:match('^'..cmd_pat..'halt') then
 		self.is_started = false
 		utilities.send_reply(self, msg, 'Stopping bot!')
-	elseif msg.text:match('^'..utilities.CMD_PAT..'script') then
-		local input = msg.text:match('^'..utilities.CMD_PAT..'script\n(.+)')
+	elseif msg.text_lower:match('^'..cmd_pat..'script') then
+		local input = msg.text_lower:match('^'..cmd_pat..'script\n(.+)')
 		if not input then
-			utilities.send_reply(self, msg, 'usage: ```\n'..utilities.CMD_PAT..'script\n'..utilities.CMD_PAT..'command <arg>\n...\n```', true)
+			utilities.send_reply(self, msg, 'usage: ```\n'..cmd_pat..'script\n'..cmd_pat..'command <arg>\n...\n```', true)
 			return
 		end
 		input = input .. '\n'

--- a/plugins/control.lua
+++ b/plugins/control.lua
@@ -5,7 +5,7 @@ local utilities = require('utilities')
 
 function control:init()
 	control.triggers = utilities.triggers(self.info.username):t('reload'):t('halt').table
-	table.insert(control.triggers, '^/script')
+	table.insert(control.triggers, '^'..utilities.CMD_PAT..'script')
 end
 
 function control:action(msg, config)
@@ -16,7 +16,7 @@ function control:action(msg, config)
 
 	if msg.date < os.time() - 1 then return end
 
-	if msg.text:match('^'..utilities.INVOCATION_PATTERN..'reload') then
+	if msg.text:match('^'..utilities.CMD_PAT..'reload') then
 		for pac, _ in pairs(package.loaded) do
 			if pac:match('^plugins%.') then
 				package.loaded[pac] = nil
@@ -30,13 +30,13 @@ function control:action(msg, config)
 		end
 		bot.init(self, config)
 		utilities.send_reply(self, msg, 'Bot reloaded!')
-	elseif msg.text:match('^'..utilities.INVOCATION_PATTERN..'halt') then
+	elseif msg.text:match('^'..utilities.CMD_PAT..'halt') then
 		self.is_started = false
 		utilities.send_reply(self, msg, 'Stopping bot!')
-	elseif msg.text:match('^'..utilities.INVOCATION_PATTERN..'script') then
-		local input = msg.text:match('^'..utilities.INVOCATION_PATTERN..'script\n(.+)')
+	elseif msg.text:match('^'..utilities.CMD_PAT..'script') then
+		local input = msg.text:match('^'..utilities.CMD_PAT..'script\n(.+)')
 		if not input then
-			utilities.send_reply(self, msg, 'usage: ```\n/script\n/command <arg>\n...\n```', true)
+			utilities.send_reply(self, msg, 'usage: ```\n'..utilities.CMD_PAT..'script\n'..utilities.CMD_PAT..'command <arg>\n...\n```', true)
 			return
 		end
 		input = input .. '\n'

--- a/plugins/currency.lua
+++ b/plugins/currency.lua
@@ -4,15 +4,15 @@ local HTTPS = require('ssl.https')
 local utilities = require('utilities')
 
 currency.command = 'cash [amount] <from> to <to>'
-currency.doc = [[```
-]]..utilities.CMD_PAT..[[cash [amount] <from> to <to>
-Example: ]]..utilities.CMD_PAT..[[cash 5 USD to EUR
+
+function currency:init(config)
+	currency.triggers = utilities.triggers(self.info.username, config.cmd_pat):t('cash', true).table
+	currency.doc = [[```
+]]..config.cmd_pat..[[cash [amount] <from> to <to>
+Example: ]]..config.cmd_pat..[[cash 5 USD to EUR
 Returns exchange rates for various currencies.
 Source: Google Finance.
 ```]]
-
-function currency:init()
-	currency.triggers = utilities.triggers(self.info.username):t('cash', true).table
 end
 
 function currency:action(msg, config)

--- a/plugins/currency.lua
+++ b/plugins/currency.lua
@@ -15,7 +15,7 @@ function currency:init()
 	currency.triggers = utilities.triggers(self.info.username):t('cash', true).table
 end
 
-function currency:action(msg)
+function currency:action(msg, config)
 
 	local input = msg.text:upper()
 	if not input:match('%a%a%a TO %a%a%a') then
@@ -36,13 +36,13 @@ function currency:action(msg)
 		url = url .. '?from=' .. from .. '&to=' .. to .. '&a=' .. amount
 		local str, res = HTTPS.request(url)
 		if res ~= 200 then
-			utilities.send_reply(self, msg, self.config.errors.connection)
+			utilities.send_reply(self, msg, config.errors.connection)
 			return
 		end
 
 		str = str:match('<span class=bld>(.*) %u+</span>')
 		if not str then
-			utilities.send_reply(self, msg, self.config.errors.results)
+			utilities.send_reply(self, msg, config.errors.results)
 			return
 		end
 

--- a/plugins/currency.lua
+++ b/plugins/currency.lua
@@ -5,8 +5,8 @@ local utilities = require('utilities')
 
 currency.command = 'cash [amount] <from> to <to>'
 currency.doc = [[```
-/cash [amount] <from> to <to>
-Example: /cash 5 USD to EUR
+]]..utilities.CMD_PAT..[[cash [amount] <from> to <to>
+Example: ]]..utilities.CMD_PAT..[[cash 5 USD to EUR
 Returns exchange rates for various currencies.
 Source: Google Finance.
 ```]]

--- a/plugins/dice.lua
+++ b/plugins/dice.lua
@@ -3,13 +3,13 @@ local dice = {}
 local utilities = require('utilities')
 
 dice.command = 'roll <nDr>'
-dice.doc = [[```
-]]..utilities.CMD_PAT..[[roll <nDr>
+
+function dice:init(config)
+	dice.triggers = utilities.triggers(self.info.username, config.cmd_pat):t('roll', true).table
+	dice.doc = [[```
+]]..config.cmd_pat..[[roll <nDr>
 Returns a set of dice rolls, where n is the number of rolls and r is the range. If only a range is given, returns only one roll.
 ```]]
-
-function dice:init()
-	dice.triggers = utilities.triggers(self.info.username):t('roll', true).table
 end
 
 function dice:action(msg)

--- a/plugins/dice.lua
+++ b/plugins/dice.lua
@@ -4,7 +4,7 @@ local utilities = require('utilities')
 
 dice.command = 'roll <nDr>'
 dice.doc = [[```
-/roll <nDr>
+]]..utilities.CMD_PAT..[[roll <nDr>
 Returns a set of dice rolls, where n is the number of rolls and r is the range. If only a range is given, returns only one roll.
 ```]]
 

--- a/plugins/dilbert.lua
+++ b/plugins/dilbert.lua
@@ -6,15 +6,15 @@ local bindings = require('bindings')
 local utilities = require('utilities')
 
 dilbert.command = 'dilbert [date]'
-dilbert.doc = [[```
-]]..utilities.CMD_PAT..[[dilbert [YYYY-MM-DD]
+
+function dilbert:init(config)
+	dilbert.triggers = utilities.triggers(self.info.username, config.cmd_pat):t('dilbert', true).table
+	dilbert.doc = [[```
+]]..config.cmd_pat..[[dilbert [YYYY-MM-DD]
 Returns the latest Dilbert strip or that of the provided date.
 Dates before the first strip will return the first strip. Dates after the last trip will return the last strip.
 Source: dilbert.com
 ```]]
-
-function dilbert:init()
-	dilbert.triggers = utilities.triggers(self.info.username):t('dilbert', true).table
 end
 
 function dilbert:action(msg, config)

--- a/plugins/dilbert.lua
+++ b/plugins/dilbert.lua
@@ -7,7 +7,7 @@ local utilities = require('utilities')
 
 dilbert.command = 'dilbert [date]'
 dilbert.doc = [[```
-/dilbert [YYYY-MM-DD]
+]]..utilities.CMD_PAT..[[dilbert [YYYY-MM-DD]
 Returns the latest Dilbert strip or that of the provided date.
 Dates before the first strip will return the first strip. Dates after the last trip will return the last strip.
 Source: dilbert.com

--- a/plugins/dilbert.lua
+++ b/plugins/dilbert.lua
@@ -17,7 +17,7 @@ function dilbert:init()
 	dilbert.triggers = utilities.triggers(self.info.username):t('dilbert', true).table
 end
 
-function dilbert:action(msg)
+function dilbert:action(msg, config)
 
 	bindings.sendChatAction(self, { chat_id = msg.chat.id, action = 'upload_photo' } )
 
@@ -28,7 +28,7 @@ function dilbert:action(msg)
 	local url = 'http://dilbert.com/strip/' .. URL.escape(input)
 	local str, res = HTTP.request(url)
 	if res ~= 200 then
-		utilities.send_reply(self, msg, self.config.errors.connection)
+		utilities.send_reply(self, msg, config.errors.connection)
 		return
 	end
 

--- a/plugins/echo.lua
+++ b/plugins/echo.lua
@@ -4,7 +4,7 @@ local utilities = require('utilities')
 
 echo.command = 'echo <text>'
 echo.doc = [[```
-/echo <text>
+]]..utilities.CMD_PAT..[[echo <text>
 Repeats a string of text.
 ```]]
 

--- a/plugins/echo.lua
+++ b/plugins/echo.lua
@@ -3,13 +3,13 @@ local echo = {}
 local utilities = require('utilities')
 
 echo.command = 'echo <text>'
-echo.doc = [[```
-]]..utilities.CMD_PAT..[[echo <text>
+
+function echo:init(config)
+	echo.triggers = utilities.triggers(self.info.username, config.cmd_pat):t('echo', true).table
+	echo.doc = [[```
+]]..config.cmd_pat..[[echo <text>
 Repeats a string of text.
 ```]]
-
-function echo:init()
-	echo.triggers = utilities.triggers(self.info.username):t('echo', true).table
 end
 
 function echo:action(msg)

--- a/plugins/eightball.lua
+++ b/plugins/eightball.lua
@@ -5,8 +5,9 @@ local utilities = require('utilities')
 eightball.command = '8ball'
 eightball.doc = '`Returns an answer from a magic 8-ball!`'
 
-function eightball:init()
-	eightball.triggers = utilities.triggers(self.info.username, {'[Yy]/[Nn]%p*$'}):t('8ball', true).table
+function eightball:init(config)
+	eightball.triggers = utilities.triggers(self.info.username, config.cmd_pat,
+		{'[Yy]/[Nn]%p*$'}):t('8ball', true).table
 end
 
 local ball_answers = {

--- a/plugins/fortune.lua
+++ b/plugins/fortune.lua
@@ -4,7 +4,7 @@ local fortune = {}
 
 local utilities = require('utilities')
 
-function fortune:init()
+function fortune:init(config)
 	local s = io.popen('fortune'):read('*all')
 	if s:match('not found$') then
 		print('fortune is not installed on this computer.')
@@ -12,7 +12,7 @@ function fortune:init()
 		return
 	end
 
-	fortune.triggers = utilities.triggers(self.info.username):t('fortune').table
+	fortune.triggers = utilities.triggers(self.info.username, config.cmd_pat):t('fortune').table
 end
 
 fortune.command = 'fortune'

--- a/plugins/gImages.lua
+++ b/plugins/gImages.lua
@@ -24,9 +24,9 @@ end
 
 gImages.command = 'image <query>'
 gImages.doc = [[```
-/image <query>
-Returns a randomized top result from Google Images. Safe search is enabled by default; use "/insfw" to disable it. NSFW results will not display an image preview.
-Alias: /i
+]]..utilities.CMD_PAT..[[image <query>
+Returns a randomized top result from Google Images. Safe search is enabled by default; use "]]..utilities.CMD_PAT..[[insfw" to disable it. NSFW results will not display an image preview.
+Alias: ]]..utilities.CMD_PAT..[[i
 ```]]
 
 function gImages:action(msg, config)
@@ -43,7 +43,7 @@ function gImages:action(msg, config)
 
 	local url = 'https://www.googleapis.com/customsearch/v1?&searchType=image&imgSize=xlarge&alt=json&num=8&start=1&key=' .. config.google_api_key .. '&cx=' .. config.google_cse_key
 
-	if not string.match(msg.text, '^/i[mage]*nsfw') then
+	if not string.match(msg.text, '^'..utilities.CMD_PAT..'i[mage]*nsfw') then
 		url = url .. '&safe=high'
 	end
 

--- a/plugins/gImages.lua
+++ b/plugins/gImages.lua
@@ -8,12 +8,12 @@ local URL = require('socket.url')
 local JSON = require('dkjson')
 local utilities = require('utilities')
 
-function gImages:init()
-	if not self.config.google_api_key then
+function gImages:init(config)
+	if not config.google_api_key then
 		print('Missing config value: google_api_key.')
 		print('gImages.lua will not be enabled.')
 		return
-	elseif not self.config.google_cse_key then
+	elseif not config.google_cse_key then
 		print('Missing config value: google_cse_key.')
 		print('gImages.lua will not be enabled.')
 		return
@@ -29,7 +29,7 @@ Returns a randomized top result from Google Images. Safe search is enabled by de
 Alias: /i
 ```]]
 
-function gImages:action(msg)
+function gImages:action(msg, config)
 
 	local input = utilities.input(msg.text)
 	if not input then
@@ -41,7 +41,7 @@ function gImages:action(msg)
 		end
 	end
 
-	local url = 'https://www.googleapis.com/customsearch/v1?&searchType=image&imgSize=xlarge&alt=json&num=8&start=1&key=' .. self.config.google_api_key .. '&cx=' .. self.config.google_cse_key
+	local url = 'https://www.googleapis.com/customsearch/v1?&searchType=image&imgSize=xlarge&alt=json&num=8&start=1&key=' .. config.google_api_key .. '&cx=' .. config.google_cse_key
 
 	if not string.match(msg.text, '^/i[mage]*nsfw') then
 		url = url .. '&safe=high'
@@ -51,13 +51,13 @@ function gImages:action(msg)
 
 	local jstr, res = HTTPS.request(url)
 	if res ~= 200 then
-		utilities.send_reply(self, msg, self.config.errors.connection)
+		utilities.send_reply(self, msg, config.errors.connection)
 		return
 	end
 
 	local jdat = JSON.decode(jstr)
 	if jdat.searchInformation.totalResults == '0' then
-		utilities.send_reply(self, msg, self.config.errors.results)
+		utilities.send_reply(self, msg, config.errors.results)
 		return
 	end
 

--- a/plugins/gImages.lua
+++ b/plugins/gImages.lua
@@ -19,15 +19,15 @@ function gImages:init(config)
 		return
 	end
 
-	gImages.triggers = utilities.triggers(self.info.username):t('image', true):t('i', true):t('insfw', true).table
+	gImages.triggers = utilities.triggers(self.info.username, config.cmd_pat):t('image', true):t('i', true):t('insfw', true).table
+	gImages.doc = [[```
+]]..config.cmd_pat..[[image <query>
+Returns a randomized top result from Google Images. Safe search is enabled by default; use "]]..config.cmd_pat..[[insfw" to disable it. NSFW results will not display an image preview.
+Alias: ]]..config.cmd_pat..[[i
+```]]
 end
 
 gImages.command = 'image <query>'
-gImages.doc = [[```
-]]..utilities.CMD_PAT..[[image <query>
-Returns a randomized top result from Google Images. Safe search is enabled by default; use "]]..utilities.CMD_PAT..[[insfw" to disable it. NSFW results will not display an image preview.
-Alias: ]]..utilities.CMD_PAT..[[i
-```]]
 
 function gImages:action(msg, config)
 
@@ -43,7 +43,7 @@ function gImages:action(msg, config)
 
 	local url = 'https://www.googleapis.com/customsearch/v1?&searchType=image&imgSize=xlarge&alt=json&num=8&start=1&key=' .. config.google_api_key .. '&cx=' .. config.google_cse_key
 
-	if not string.match(msg.text, '^'..utilities.CMD_PAT..'i[mage]*nsfw') then
+	if not string.match(msg.text, '^'..config.cmd_pat..'i[mage]*nsfw') then
 		url = url .. '&safe=high'
 	end
 

--- a/plugins/gMaps.lua
+++ b/plugins/gMaps.lua
@@ -14,7 +14,7 @@ function gMaps:init()
 	gMaps.triggers = utilities.triggers(self.info.username):t('location', true):t('loc', true).table
 end
 
-function gMaps:action(msg)
+function gMaps:action(msg, config)
 
 	local input = utilities.input(msg.text)
 	if not input then
@@ -26,7 +26,7 @@ function gMaps:action(msg)
 		end
 	end
 
-	local coords = utilities.get_coords(self, input)
+	local coords = utilities.get_coords(self, input, config)
 	if type(coords) == 'string' then
 		utilities.send_reply(self, msg, coords)
 		return

--- a/plugins/gMaps.lua
+++ b/plugins/gMaps.lua
@@ -4,14 +4,14 @@ local bindings = require('bindings')
 local utilities = require('utilities')
 
 gMaps.command = 'location <query>'
-gMaps.doc = [[```
-]]..utilities.CMD_PAT..[[location <query>
-Returns a location from Google Maps.
-Alias: ]]..utilities.CMD_PAT..[[loc
-```]]
 
-function gMaps:init()
-	gMaps.triggers = utilities.triggers(self.info.username):t('location', true):t('loc', true).table
+function gMaps:init(config)
+	gMaps.triggers = utilities.triggers(self.info.username, config.cmd_pat):t('location', true):t('loc', true).table
+	gMaps.doc = [[```
+]]..config.cmd_pat..[[location <query>
+Returns a location from Google Maps.
+Alias: ]]..config.cmd_pat..[[loc
+```]]
 end
 
 function gMaps:action(msg, config)

--- a/plugins/gMaps.lua
+++ b/plugins/gMaps.lua
@@ -5,9 +5,9 @@ local utilities = require('utilities')
 
 gMaps.command = 'location <query>'
 gMaps.doc = [[```
-/location <query>
+]]..utilities.CMD_PAT..[[location <query>
 Returns a location from Google Maps.
-Alias: /loc
+Alias: ]]..utilities.CMD_PAT..[[loc
 ```]]
 
 function gMaps:init()
@@ -26,7 +26,7 @@ function gMaps:action(msg, config)
 		end
 	end
 
-	local coords = utilities.get_coords(self, input, config)
+	local coords = utilities.get_coords(input, config)
 	if type(coords) == 'string' then
 		utilities.send_reply(self, msg, coords)
 		return

--- a/plugins/gSearch.lua
+++ b/plugins/gSearch.lua
@@ -7,9 +7,9 @@ local utilities = require('utilities')
 
 gSearch.command = 'google <query>'
 gSearch.doc = [[```
-/google <query>
-Returns four (if group) or eight (if private message) results from Google. Safe search is enabled by default, use "/gnsfw" to disable it.
-Alias: /g
+]]..utilities.CMD_PAT..[[google <query>
+Returns four (if group) or eight (if private message) results from Google. Safe search is enabled by default, use "]]..utilities.CMD_PAT..[[gnsfw" to disable it.
+Alias: ]]..utilities.CMD_PAT..[[g
 ```]]
 
 function gSearch:init()
@@ -36,7 +36,7 @@ function gSearch:action(msg, config)
 		url = url .. '&rsz=4'
 	end
 
-	if not string.match(msg.text, '^/g[oogle]*nsfw') then
+	if not string.match(msg.text, '^'..utilities.CMD_PAT..'g[oogle]*nsfw') then
 		url = url .. '&safe=active'
 	end
 

--- a/plugins/gSearch.lua
+++ b/plugins/gSearch.lua
@@ -16,7 +16,7 @@ function gSearch:init()
 	gSearch.triggers = utilities.triggers(self.info.username):t('g', true):t('google', true):t('gnsfw', true).table
 end
 
-function gSearch:action(msg)
+function gSearch:action(msg, config)
 
 	local input = utilities.input(msg.text)
 	if not input then
@@ -44,17 +44,17 @@ function gSearch:action(msg)
 
 	local jstr, res = HTTPS.request(url)
 	if res ~= 200 then
-		utilities.send_reply(self, msg, self.config.errors.connection)
+		utilities.send_reply(self, msg, config.errors.connection)
 		return
 	end
 
 	local jdat = JSON.decode(jstr)
 	if not jdat.responseData then
-		utilities.send_reply(self, msg, self.config.errors.connection)
+		utilities.send_reply(self, msg, config.errors.connection)
 		return
 	end
 	if not jdat.responseData.results[1] then
-		utilities.send_reply(self, msg, self.config.errors.results)
+		utilities.send_reply(self, msg, config.errors.results)
 		return
 	end
 

--- a/plugins/gSearch.lua
+++ b/plugins/gSearch.lua
@@ -6,14 +6,14 @@ local JSON = require('dkjson')
 local utilities = require('utilities')
 
 gSearch.command = 'google <query>'
-gSearch.doc = [[```
-]]..utilities.CMD_PAT..[[google <query>
-Returns four (if group) or eight (if private message) results from Google. Safe search is enabled by default, use "]]..utilities.CMD_PAT..[[gnsfw" to disable it.
-Alias: ]]..utilities.CMD_PAT..[[g
-```]]
 
-function gSearch:init()
-	gSearch.triggers = utilities.triggers(self.info.username):t('g', true):t('google', true):t('gnsfw', true).table
+function gSearch:init(config)
+	gSearch.triggers = utilities.triggers(self.info.username, config.cmd_pat):t('g', true):t('google', true):t('gnsfw', true).table
+	gSearch.doc = [[```
+]]..config.cmd_pat..[[google <query>
+Returns four (if group) or eight (if private message) results from Google. Safe search is enabled by default, use "]]..config.cmd_pat..[[gnsfw" to disable it.
+Alias: ]]..config.cmd_pat..[[g
+```]]
 end
 
 function gSearch:action(msg, config)
@@ -36,7 +36,7 @@ function gSearch:action(msg, config)
 		url = url .. '&rsz=4'
 	end
 
-	if not string.match(msg.text, '^'..utilities.CMD_PAT..'g[oogle]*nsfw') then
+	if not string.match(msg.text, '^'..config.cmd_pat..'g[oogle]*nsfw') then
 		url = url .. '&safe=active'
 	end
 

--- a/plugins/greetings.lua
+++ b/plugins/greetings.lua
@@ -6,46 +6,44 @@ local greetings = {}
 
 local utilities = require('utilities')
 
-function greetings:init()
-	if not self.config.greetings then
-		self.config.greetings = {
-			['Hello, #NAME.'] = {
-				'hello',
-				'hey',
-				'sup',
-				'hi',
-				'good morning',
-				'good day',
-				'good afternoon',
-				'good evening'
-			},
-			['Goodbye, #NAME.'] = {
-				'bye',
-				'later',
-				'see ya',
-				'good night'
-			},
-			['Welcome back, #NAME.'] = {
-				'i\'m home',
-				'i\'m back'
-			},
-			['You\'re welcome, #NAME.'] = {
-				'thanks',
-				'thank you'
-			}
+function greetings:init(config)
+	config.greetings = config.greetings or {
+		['Hello, #NAME.'] = {
+			'hello',
+			'hey',
+			'sup',
+			'hi',
+			'good morning',
+			'good day',
+			'good afternoon',
+			'good evening'
+		},
+		['Goodbye, #NAME.'] = {
+			'bye',
+			'later',
+			'see ya',
+			'good night'
+		},
+		['Welcome back, #NAME.'] = {
+			'i\'m home',
+			'i\'m back'
+		},
+		['You\'re welcome, #NAME.'] = {
+			'thanks',
+			'thank you'
 		}
-	end
+	}
 
 	greetings.triggers = {
 		self.info.first_name:lower() .. '%p*$'
 	}
 end
 
-function greetings:action(msg)
+function greetings:action(msg, config)
 
 	local nick = self.database.users[msg.from.id_str].nickname or msg.from.first_name
 
-	for trigger,responses in pairs(self.config.greetings) do
+	for trigger,responses in pairs(config.greetings) do
 		for _,response in pairs(responses) do
 			if msg.text_lower:match(response..',? '..self.info.first_name:lower()) then
 				utilities.send_message(self, msg.chat.id, utilities.latcyr(trigger:gsub('#NAME', nick)))

--- a/plugins/hackernews.lua
+++ b/plugins/hackernews.lua
@@ -6,13 +6,13 @@ local bindings = require('bindings')
 local utilities = require('utilities')
 
 hackernews.command = 'hackernews'
-hackernews.doc = [[```
-Returns four (if group) or eight (if private message) top stories from Hacker News.
-Alias: ]]..utilities.CMD_PAT..[[hn
-```]]
 
-function hackernews:init()
-	hackernews.triggers = utilities.triggers(self.info.username):t('hackernews', true):t('hn', true).table
+function hackernews:init(config)
+	hackernews.triggers = utilities.triggers(self.info.username, config.cmd_pat):t('hackernews', true):t('hn', true).table
+	hackernews.doc = [[```
+Returns four (if group) or eight (if private message) top stories from Hacker News.
+Alias: ]]..config.cmd_pat..[[hn
+```]]
 end
 
 function hackernews:action(msg, config)

--- a/plugins/hackernews.lua
+++ b/plugins/hackernews.lua
@@ -8,7 +8,7 @@ local utilities = require('utilities')
 hackernews.command = 'hackernews'
 hackernews.doc = [[```
 Returns four (if group) or eight (if private message) top stories from Hacker News.
-Alias: /hn
+Alias: ]]..utilities.CMD_PAT..[[hn
 ```]]
 
 function hackernews:init()

--- a/plugins/hackernews.lua
+++ b/plugins/hackernews.lua
@@ -15,13 +15,13 @@ function hackernews:init()
 	hackernews.triggers = utilities.triggers(self.info.username):t('hackernews', true):t('hn', true).table
 end
 
-function hackernews:action(msg)
+function hackernews:action(msg, config)
 
 	bindings.sendChatAction(self, { chat_id = msg.chat.id, action = 'typing' } )
 
 	local jstr, res = HTTPS.request('https://hacker-news.firebaseio.com/v0/topstories.json')
 	if res ~= 200 then
-		utilities.send_reply(self, msg, self.config.errors.connection)
+		utilities.send_reply(self, msg, config.errors.connection)
 		return
 	end
 
@@ -37,7 +37,7 @@ function hackernews:action(msg)
 		local res_url = 'https://hacker-news.firebaseio.com/v0/item/' .. jdat[i] .. '.json'
 		jstr, res = HTTPS.request(res_url)
 		if res ~= 200 then
-			utilities.send_reply(self, msg, self.config.errors.connection)
+			utilities.send_reply(self, msg, config.errors.connection)
 			return
 		end
 		local res_jdat = JSON.decode(jstr)
@@ -47,7 +47,7 @@ function hackernews:action(msg)
 		end
 		local url = res_jdat.url
 		if not url then
-			utilities.send_reply(self, msg, self.config.errors.connection)
+			utilities.send_reply(self, msg, config.errors.connection)
 			return
 		end
 		if url:find('%(') then

--- a/plugins/hearthstone.lua
+++ b/plugins/hearthstone.lua
@@ -6,7 +6,7 @@ local hearthstone = {}
 local JSON = require('dkjson')
 local utilities = require('utilities')
 
-function hearthstone:init()
+function hearthstone:init(config)
 	if not self.database.hearthstone or os.time() > self.database.hearthstone.expiration then
 
 		print('Downloading Hearthstone database...')
@@ -36,15 +36,15 @@ function hearthstone:init()
 
 	end
 
-	hearthstone.triggers = utilities.triggers(self.info.username):t('hearthstone', true):t('hs').table
+	hearthstone.triggers = utilities.triggers(self.info.username, config.cmd_pat):t('hearthstone', true):t('hs').table
+	hearthstone.doc = [[```
+]]..config.cmd_pat..[[hearthstone <query>
+Returns Hearthstone card info.
+Alias: ]]..config.cmd_pat..[[hs
+```]]
 end
 
 hearthstone.command = 'hearthstone <query>'
-hearthstone.doc = [[```
-]]..utilities.CMD_PAT..[[hearthstone <query>
-Returns Hearthstone card info.
-Alias: ]]..utilities.CMD_PAT..[[hs
-```]]
 
 local function format_card(card)
 

--- a/plugins/hearthstone.lua
+++ b/plugins/hearthstone.lua
@@ -41,9 +41,9 @@ end
 
 hearthstone.command = 'hearthstone <query>'
 hearthstone.doc = [[```
-/hearthstone <query>
+]]..utilities.CMD_PAT..[[hearthstone <query>
 Returns Hearthstone card info.
-Alias: /hs
+Alias: ]]..utilities.CMD_PAT..[[hs
 ```]]
 
 local function format_card(card)

--- a/plugins/hearthstone.lua
+++ b/plugins/hearthstone.lua
@@ -102,7 +102,7 @@ local function format_card(card)
 
 end
 
-function hearthstone:action(msg)
+function hearthstone:action(msg, config)
 
 	local input = utilities.input(msg.text_lower)
 	if not input then
@@ -119,7 +119,7 @@ function hearthstone:action(msg)
 
 	output = utilities.trim(output)
 	if output:len() == 0 then
-		utilities.send_reply(self, msg, self.config.errors.results)
+		utilities.send_reply(self, msg, config.errors.results)
 		return
 	end
 

--- a/plugins/help.lua
+++ b/plugins/help.lua
@@ -10,19 +10,19 @@ local help_text
 function help:init()
 
 	local commandlist = {}
-	help_text = '*Available commands:*\n• /'
+	help_text = '*Available commands:*\n• '..utilities.CMD_PAT
 
 	for _,plugin in ipairs(self.plugins) do
 		if plugin.command then
 			table.insert(commandlist, plugin.command)
-			--help_text = help_text .. '\n• /' .. plugin.command:gsub('%[', '\\[')
+			--help_text = help_text .. '\n• '..utilities.CMD_PAT .. plugin.command:gsub('%[', '\\[')
 		end
 	end
 
 	table.insert(commandlist, 'help [command]')
 	table.sort(commandlist)
 
-	help_text = help_text .. table.concat(commandlist, '\n• /') .. '\nArguments: <required> [optional]'
+	help_text = help_text .. table.concat(commandlist, '\n• '..utilities.CMD_PAT) .. '\nArguments: <required> [optional]'
 
 	help_text = help_text:gsub('%[', '\\[')
 

--- a/plugins/help.lua
+++ b/plugins/help.lua
@@ -7,26 +7,26 @@ local utilities = require('utilities')
 
 local help_text
 
-function help:init()
+function help:init(config)
 
 	local commandlist = {}
-	help_text = '*Available commands:*\n• '..utilities.CMD_PAT
+	help_text = '*Available commands:*\n• '..config.cmd_pat
 
 	for _,plugin in ipairs(self.plugins) do
 		if plugin.command then
 			table.insert(commandlist, plugin.command)
-			--help_text = help_text .. '\n• '..utilities.CMD_PAT .. plugin.command:gsub('%[', '\\[')
+			--help_text = help_text .. '\n• '..config.cmd_pat .. plugin.command:gsub('%[', '\\[')
 		end
 	end
 
 	table.insert(commandlist, 'help [command]')
 	table.sort(commandlist)
 
-	help_text = help_text .. table.concat(commandlist, '\n• '..utilities.CMD_PAT) .. '\nArguments: <required> [optional]'
+	help_text = help_text .. table.concat(commandlist, '\n• '..config.cmd_pat) .. '\nArguments: <required> [optional]'
 
 	help_text = help_text:gsub('%[', '\\[')
 
-	help.triggers = utilities.triggers(self.info.username):t('help', true):t('h', true).table
+	help.triggers = utilities.triggers(self.info.username, config.cmd_pat):t('help', true):t('h', true).table
 
 end
 

--- a/plugins/imdb.lua
+++ b/plugins/imdb.lua
@@ -15,7 +15,7 @@ function imdb:init()
 	imdb.triggers = utilities.triggers(self.info.username):t('imdb', true).table
 end
 
-function imdb:action(msg)
+function imdb:action(msg, config)
 
 	local input = utilities.input(msg.text)
 	if not input then
@@ -31,14 +31,14 @@ function imdb:action(msg)
 
 	local jstr, res = HTTP.request(url)
 	if res ~= 200 then
-		utilities.send_reply(self, msg, self.config.errors.connection)
+		utilities.send_reply(self, msg, config.errors.connection)
 		return
 	end
 
 	local jdat = JSON.decode(jstr)
 
 	if jdat.Response ~= 'True' then
-		utilities.send_reply(self, msg, self.config.errors.results)
+		utilities.send_reply(self, msg, config.errors.results)
 		return
 	end
 

--- a/plugins/imdb.lua
+++ b/plugins/imdb.lua
@@ -7,7 +7,7 @@ local utilities = require('utilities')
 
 imdb.command = 'imdb <query>'
 imdb.doc = [[```
-/imdb <query>
+]]..utilities.CMD_PAT..[[imdb <query>
 Returns an IMDb entry.
 ```]]
 

--- a/plugins/imdb.lua
+++ b/plugins/imdb.lua
@@ -6,13 +6,13 @@ local JSON = require('dkjson')
 local utilities = require('utilities')
 
 imdb.command = 'imdb <query>'
-imdb.doc = [[```
-]]..utilities.CMD_PAT..[[imdb <query>
+
+function imdb:init(config)
+	imdb.triggers = utilities.triggers(self.info.username, config.cmd_pat):t('imdb', true).table
+	imdb.doc = [[```
+]]..config.cmd_pat..[[imdb <query>
 Returns an IMDb entry.
 ```]]
-
-function imdb:init()
-	imdb.triggers = utilities.triggers(self.info.username):t('imdb', true).table
 end
 
 function imdb:action(msg, config)

--- a/plugins/lastfm.lua
+++ b/plugins/lastfm.lua
@@ -8,8 +8,8 @@ local URL = require('socket.url')
 local JSON = require('dkjson')
 local utilities = require('utilities')
 
-function lastfm:init()
-	if not self.config.lastfm_api_key then
+function lastfm:init(config)
+	if not config.lastfm_api_key then
 		print('Missing config value: lastfm_api_key.')
 		print('lastfm.lua will not be enabled.')
 		return
@@ -27,7 +27,7 @@ Returns what you are or were last listening to. If you specify a username, info 
 Sets your last.fm username. Otherwise, /np will use your Telegram username. Use "/fmset --" to delete it.
 ```]]
 
-function lastfm:action(msg)
+function lastfm:action(msg, config)
 
 	local input = utilities.input(msg.text)
 
@@ -47,7 +47,7 @@ function lastfm:action(msg)
 		return
 	end
 
-	local url = 'http://ws.audioscrobbler.com/2.0/?method=user.getrecenttracks&format=json&limit=1&api_key=' .. self.config.lastfm_api_key .. '&user='
+	local url = 'http://ws.audioscrobbler.com/2.0/?method=user.getrecenttracks&format=json&limit=1&api_key=' .. config.lastfm_api_key .. '&user='
 
 	local username
 	local alert = ''
@@ -72,7 +72,7 @@ function lastfm:action(msg)
 			jstr, res = HTTP.request(url)
 	end)
 	if res ~= 200 then
-		utilities.send_reply(self, msg, self.config.errors.connection)
+		utilities.send_reply(self, msg, config.errors.connection)
 		return
 	end
 

--- a/plugins/lastfm.lua
+++ b/plugins/lastfm.lua
@@ -20,21 +20,21 @@ end
 
 lastfm.command = 'lastfm'
 lastfm.doc = [[```
-/np [username]
+]]..utilities.CMD_PAT..[[np [username]
 Returns what you are or were last listening to. If you specify a username, info will be returned for that username.
 
-/fmset <username>
-Sets your last.fm username. Otherwise, /np will use your Telegram username. Use "/fmset --" to delete it.
+]]..utilities.CMD_PAT..[[fmset <username>
+Sets your last.fm username. Otherwise, ]]..utilities.CMD_PAT..[[np will use your Telegram username. Use "]]..utilities.CMD_PAT..[[fmset --" to delete it.
 ```]]
 
 function lastfm:action(msg, config)
 
 	local input = utilities.input(msg.text)
 
-	if string.match(msg.text, '^/lastfm') then
+	if string.match(msg.text, '^'..utilities.CMD_PAT..'lastfm') then
 		utilities.send_message(self, msg.chat.id, lastfm.doc, true, msg.message_id, true)
 		return
-	elseif string.match(msg.text, '^/fmset') then
+	elseif string.match(msg.text, '^'..utilities.CMD_PAT..'fmset') then
 		if not input then
 			utilities.send_message(self, msg.chat.id, lastfm.doc, true, msg.message_id, true)
 		elseif input == '--' or input == utilities.char.em_dash then
@@ -57,10 +57,10 @@ function lastfm:action(msg, config)
 		username = self.database.users[msg.from.id_str].lastfm
 	elseif msg.from.username then
 		username = msg.from.username
-		alert = '\n\nYour username has been set to ' .. username .. '.\nTo change it, use /fmset <username>.'
+		alert = '\n\nYour username has been set to ' .. username .. '.\nTo change it, use '..utilities.CMD_PAT..'fmset <username>.'
 		self.database.users[msg.from.id_str].lastfm = username
 	else
-		utilities.send_reply(self, msg, 'Please specify your last.fm username or set it with /fmset.')
+		utilities.send_reply(self, msg, 'Please specify your last.fm username or set it with '..utilities.CMD_PAT..'fmset.')
 		return
 	end
 
@@ -78,7 +78,7 @@ function lastfm:action(msg, config)
 
 	local jdat = JSON.decode(jstr)
 	if jdat.error then
-		utilities.send_reply(self, msg, 'Please specify your last.fm username or set it with /fmset.')
+		utilities.send_reply(self, msg, 'Please specify your last.fm username or set it with '..utilities.CMD_PAT..'fmset.')
 		return
 	end
 

--- a/plugins/lastfm.lua
+++ b/plugins/lastfm.lua
@@ -15,26 +15,26 @@ function lastfm:init(config)
 		return
 	end
 
-	lastfm.triggers = utilities.triggers(self.info.username):t('lastfm', true):t('np', true):t('fmset', true).table
+	lastfm.triggers = utilities.triggers(self.info.username, config.cmd_pat):t('lastfm', true):t('np', true):t('fmset', true).table
+	lastfm.doc = [[```
+]]..config.cmd_pat..[[np [username]
+Returns what you are or were last listening to. If you specify a username, info will be returned for that username.
+
+]]..config.cmd_pat..[[fmset <username>
+Sets your last.fm username. Otherwise, ]]..config.cmd_pat..[[np will use your Telegram username. Use "]]..config.cmd_pat..[[fmset --" to delete it.
+```]]
 end
 
 lastfm.command = 'lastfm'
-lastfm.doc = [[```
-]]..utilities.CMD_PAT..[[np [username]
-Returns what you are or were last listening to. If you specify a username, info will be returned for that username.
-
-]]..utilities.CMD_PAT..[[fmset <username>
-Sets your last.fm username. Otherwise, ]]..utilities.CMD_PAT..[[np will use your Telegram username. Use "]]..utilities.CMD_PAT..[[fmset --" to delete it.
-```]]
 
 function lastfm:action(msg, config)
 
 	local input = utilities.input(msg.text)
 
-	if string.match(msg.text, '^'..utilities.CMD_PAT..'lastfm') then
+	if string.match(msg.text, '^'..config.cmd_pat..'lastfm') then
 		utilities.send_message(self, msg.chat.id, lastfm.doc, true, msg.message_id, true)
 		return
-	elseif string.match(msg.text, '^'..utilities.CMD_PAT..'fmset') then
+	elseif string.match(msg.text, '^'..config.cmd_pat..'fmset') then
 		if not input then
 			utilities.send_message(self, msg.chat.id, lastfm.doc, true, msg.message_id, true)
 		elseif input == '--' or input == utilities.char.em_dash then
@@ -57,10 +57,10 @@ function lastfm:action(msg, config)
 		username = self.database.users[msg.from.id_str].lastfm
 	elseif msg.from.username then
 		username = msg.from.username
-		alert = '\n\nYour username has been set to ' .. username .. '.\nTo change it, use '..utilities.CMD_PAT..'fmset <username>.'
+		alert = '\n\nYour username has been set to ' .. username .. '.\nTo change it, use '..config.cmd_pat..'fmset <username>.'
 		self.database.users[msg.from.id_str].lastfm = username
 	else
-		utilities.send_reply(self, msg, 'Please specify your last.fm username or set it with '..utilities.CMD_PAT..'fmset.')
+		utilities.send_reply(self, msg, 'Please specify your last.fm username or set it with '..config.cmd_pat..'fmset.')
 		return
 	end
 
@@ -78,7 +78,7 @@ function lastfm:action(msg, config)
 
 	local jdat = JSON.decode(jstr)
 	if jdat.error then
-		utilities.send_reply(self, msg, 'Please specify your last.fm username or set it with '..utilities.CMD_PAT..'fmset.')
+		utilities.send_reply(self, msg, 'Please specify your last.fm username or set it with '..config.cmd_pat..'fmset.')
 		return
 	end
 

--- a/plugins/luarun.lua
+++ b/plugins/luarun.lua
@@ -8,9 +8,9 @@ function luarun:init()
 	luarun.triggers = utilities.triggers(self.info.username):t('lua', true):t('return', true).table
 end
 
-function luarun:action(msg)
+function luarun:action(msg, config)
 
-	if msg.from.id ~= self.config.admin then
+	if msg.from.id ~= config.admin then
 		return true
 	end
 

--- a/plugins/luarun.lua
+++ b/plugins/luarun.lua
@@ -4,8 +4,8 @@ local utilities = require('utilities')
 local URL = require('socket.url')
 local JSON = require('dkjson')
 
-function luarun:init()
-	luarun.triggers = utilities.triggers(self.info.username):t('lua', true):t('return', true).table
+function luarun:init(config)
+	luarun.triggers = utilities.triggers(self.info.username, config.cmd_pat):t('lua', true):t('return', true).table
 end
 
 function luarun:action(msg, config)
@@ -20,7 +20,7 @@ function luarun:action(msg, config)
 		return
 	end
 
-	if msg.text_lower:match('^'..utilities.CMD_PAT..'return') then
+	if msg.text_lower:match('^'..config.cmd_pat..'return') then
 		input = 'return ' .. input
 	end
 
@@ -32,8 +32,8 @@ function luarun:action(msg, config)
 		local URL = require('socket.url')
 		local HTTP = require('socket.http')
 		local HTTPS = require('ssl.https')
-		return function (self, msg) ]] .. input .. [[ end
-	]] )()(self, msg)
+		return function (self, msg, config) ]] .. input .. [[ end
+	]] )()(self, msg, config)
 	if output == nil then
 		output = 'Done!'
 	else

--- a/plugins/luarun.lua
+++ b/plugins/luarun.lua
@@ -20,7 +20,7 @@ function luarun:action(msg, config)
 		return
 	end
 
-	if msg.text_lower:match('^/return') then
+	if msg.text_lower:match('^'..utilities.CMD_PAT..'return') then
 		input = 'return ' .. input
 	end
 

--- a/plugins/me.lua
+++ b/plugins/me.lua
@@ -6,11 +6,11 @@ function me:init()
 	me.triggers = utilities.triggers(self.info.username):t('me', true).table
 end
 
-function me:action(msg)
+function me:action(msg, config)
 
 	local target = self.database.users[msg.from.id_str]
 
-	if msg.from.id == self.config.admin and (msg.reply_to_message or utilities.input(msg.text)) then
+	if msg.from.id == config.admin and (msg.reply_to_message or utilities.input(msg.text)) then
 		target = utilities.user_from_message(self, msg, true)
 		if target.err then
 			utilities.send_reply(self, msg, target.err)

--- a/plugins/me.lua
+++ b/plugins/me.lua
@@ -2,8 +2,8 @@ local me = {}
 
 local utilities = require('utilities')
 
-function me:init()
-	me.triggers = utilities.triggers(self.info.username):t('me', true).table
+function me:init(config)
+	me.triggers = utilities.triggers(self.info.username, config.cmd_pat):t('me', true).table
 end
 
 function me:action(msg, config)

--- a/plugins/nick.lua
+++ b/plugins/nick.lua
@@ -12,11 +12,11 @@ function nick:init()
 	nick.triggers = utilities.triggers(self.info.username):t('nick', true).table
 end
 
-function nick:action(msg)
+function nick:action(msg, config)
 
 	local target = msg.from
 
-	if msg.from.id == self.config.admin and msg.reply_to_message then
+	if msg.from.id == config.admin and msg.reply_to_message then
 		target = msg.reply_to_message.from
 		target.id_str = tostring(target.id)
 		target.name = target.first_name

--- a/plugins/nick.lua
+++ b/plugins/nick.lua
@@ -3,13 +3,13 @@ local nick = {}
 local utilities = require('utilities')
 
 nick.command = 'nick <nickname>'
-nick.doc = [[```
-]]..utilities.CMD_PAT..[[nick <nickname>
-Set your nickname. Use "]]..utilities.CMD_PAT..[[nick --" to delete it.
-```]]
 
-function nick:init()
-	nick.triggers = utilities.triggers(self.info.username):t('nick', true).table
+function nick:init(config)
+	nick.triggers = utilities.triggers(self.info.username, config.cmd_pat):t('nick', true).table
+	nick.doc = [[```
+]]..config.cmd_pat..[[nick <nickname>
+Set your nickname. Use "]]..config.cmd_pat..[[nick --" to delete it.
+```]]
 end
 
 function nick:action(msg, config)

--- a/plugins/nick.lua
+++ b/plugins/nick.lua
@@ -4,8 +4,8 @@ local utilities = require('utilities')
 
 nick.command = 'nick <nickname>'
 nick.doc = [[```
-/nick <nickname>
-Set your nickname. Use "/nick --" to delete it.
+]]..utilities.CMD_PAT..[[nick <nickname>
+Set your nickname. Use "]]..utilities.CMD_PAT..[[nick --" to delete it.
 ```]]
 
 function nick:init()

--- a/plugins/ping.lua
+++ b/plugins/ping.lua
@@ -9,7 +9,7 @@ function ping:init()
 end
 
 function ping:action(msg)
-	local output = msg.text_lower:match('^/ping') and 'Pong!' or 'Annyong.'
+	local output = msg.text_lower:match('^'..utilities.CMD_PAT..'ping') and 'Pong!' or 'Annyong.'
 	utilities.send_message(self, msg.chat.id, output)
 end
 

--- a/plugins/ping.lua
+++ b/plugins/ping.lua
@@ -4,12 +4,12 @@ local ping = {}
 
 local utilities = require('utilities')
 
-function ping:init()
-	ping.triggers = utilities.triggers(self.info.username):t('ping'):t('annyong').table
+function ping:init(config)
+	ping.triggers = utilities.triggers(self.info.username, config.cmd_pat):t('ping'):t('annyong').table
 end
 
-function ping:action(msg)
-	local output = msg.text_lower:match('^'..utilities.CMD_PAT..'ping') and 'Pong!' or 'Annyong.'
+function ping:action(msg, config)
+	local output = msg.text_lower:match('^'..config.cmd_pat..'ping') and 'Pong!' or 'Annyong.'
 	utilities.send_message(self, msg.chat.id, output)
 end
 

--- a/plugins/pokedex.lua
+++ b/plugins/pokedex.lua
@@ -16,7 +16,7 @@ function pokedex:init()
 	pokedex.triggers = utilities.triggers(self.info.username):t('pokedex', true):t('dex', true).table
 end
 
-function pokedex:action(msg)
+function pokedex:action(msg, config)
 
 	bindings.sendChatAction(self, { chat_id = msg.chat.id, action = 'typing' } )
 
@@ -35,7 +35,7 @@ function pokedex:action(msg)
 	local dex_url = url .. '/api/v1/pokemon/' .. input
 	local dex_jstr, res = HTTP.request(dex_url)
 	if res ~= 200 then
-		utilities.send_reply(self, msg, self.config.errors.connection)
+		utilities.send_reply(self, msg, config.errors.connection)
 		return
 	end
 
@@ -44,7 +44,7 @@ function pokedex:action(msg)
 	local desc_url = url .. dex_jdat.descriptions[math.random(#dex_jdat.descriptions)].resource_uri
 	local desc_jstr, _ = HTTP.request(desc_url)
 	if res ~= 200 then
-		utilities.send_reply(self, msg, self.config.errors.connection)
+		utilities.send_reply(self, msg, config.errors.connection)
 		return
 	end
 

--- a/plugins/pokedex.lua
+++ b/plugins/pokedex.lua
@@ -6,14 +6,14 @@ local bindings = require('bindings')
 local utilities = require('utilities')
 
 pokedex.command = 'pokedex <query>'
-pokedex.doc = [[```
-]]..utilities.CMD_PAT..[[pokedex <query>
-Returns a Pokedex entry from pokeapi.co.
-Alias: ]]..utilities.CMD_PAT..[[dex
-```]]
 
-function pokedex:init()
-	pokedex.triggers = utilities.triggers(self.info.username):t('pokedex', true):t('dex', true).table
+function pokedex:init(config)
+	pokedex.triggers = utilities.triggers(self.info.username, config.cmd_pat):t('pokedex', true):t('dex', true).table
+	pokedex.doc = [[```
+]]..config.cmd_pat..[[pokedex <query>
+Returns a Pokedex entry from pokeapi.co.
+Alias: ]]..config.cmd_pat..[[dex
+```]]
 end
 
 function pokedex:action(msg, config)

--- a/plugins/pokedex.lua
+++ b/plugins/pokedex.lua
@@ -7,9 +7,9 @@ local utilities = require('utilities')
 
 pokedex.command = 'pokedex <query>'
 pokedex.doc = [[```
-/pokedex <query>
+]]..utilities.CMD_PAT..[[pokedex <query>
 Returns a Pokedex entry from pokeapi.co.
-Alias: /dex
+Alias: ]]..utilities.CMD_PAT..[[dex
 ```]]
 
 function pokedex:init()

--- a/plugins/preview.lua
+++ b/plugins/preview.lua
@@ -5,7 +5,7 @@ local utilities = require('utilities')
 
 preview.command = 'preview <link>'
 preview.doc = [[```
-/preview <link>
+]]..utilities.CMD_PAT..[[preview <link>
 Returns a full-message, "unlinked" preview.
 ```]]
 

--- a/plugins/preview.lua
+++ b/plugins/preview.lua
@@ -4,13 +4,13 @@ local HTTP = require('socket.http')
 local utilities = require('utilities')
 
 preview.command = 'preview <link>'
-preview.doc = [[```
-]]..utilities.CMD_PAT..[[preview <link>
+
+function preview:init(config)
+	preview.triggers = utilities.triggers(self.info.username, config.cmd_pat):t('preview', true).table
+	preview.doc = [[```
+]]..config.cmd_pat..[[preview <link>
 Returns a full-message, "unlinked" preview.
 ```]]
-
-function preview:init()
-	preview.triggers = utilities.triggers(self.info.username):t('preview', true).table
 end
 
 function preview:action(msg)

--- a/plugins/pun.lua
+++ b/plugins/pun.lua
@@ -5,8 +5,8 @@ local utilities = require('utilities')
 pun.command = 'pun'
 pun.doc = '`Returns a pun.`'
 
-function pun:init()
-	pun.triggers = utilities.triggers(self.info.username):t('pun').table
+function pun:init(config)
+	pun.triggers = utilities.triggers(self.info.username, config.cmd_pat):t('pun').table
 end
 
 local puns = {

--- a/plugins/reactions.lua
+++ b/plugins/reactions.lua
@@ -25,24 +25,24 @@ local mapping = {
 
 local help
 
-function reactions:init()
+function reactions:init(config)
 	-- Generate a "help" message triggered by "/reactions".
 	help = 'Reactions:\n'
-	reactions.triggers = utilities.triggers(self.info.username):t('reactions').table
+	reactions.triggers = utilities.triggers(self.info.username, config.cmd_pat):t('reactions').table
 	for trigger,reaction in pairs(mapping) do
-		help = help .. '• ' .. utilities.CMD_PAT .. trigger:gsub('.%?', '') .. ': ' .. reaction .. '\n'
-		table.insert(reactions.triggers, utilities.CMD_PAT..trigger)
-		table.insert(reactions.triggers, utilities.CMD_PAT..trigger..'@'..self.info.username:lower())
+		help = help .. '• ' .. config.cmd_pat .. trigger:gsub('.%?', '') .. ': ' .. reaction .. '\n'
+		table.insert(reactions.triggers, config.cmd_pat..trigger)
+		table.insert(reactions.triggers, config.cmd_pat..trigger..'@'..self.info.username:lower())
 	end
 end
 
-function reactions:action(msg)
-	if string.match(msg.text_lower, utilities.CMD_PAT..'reactions') then
+function reactions:action(msg, config)
+	if string.match(msg.text_lower, config.cmd_pat..'reactions') then
 		utilities.send_message(self, msg.chat.id, help)
 		return
 	end
 	for trigger,reaction in pairs(mapping) do
-		if string.match(msg.text_lower, utilities.CMD_PAT..trigger) then
+		if string.match(msg.text_lower, config.cmd_pat..trigger) then
 			utilities.send_message(self, msg.chat.id, reaction)
 			return
 		end

--- a/plugins/reactions.lua
+++ b/plugins/reactions.lua
@@ -30,19 +30,19 @@ function reactions:init()
 	help = 'Reactions:\n'
 	reactions.triggers = utilities.triggers(self.info.username):t('reactions').table
 	for trigger,reaction in pairs(mapping) do
-		help = help .. '• ' .. utilities.INVOCATION_PATTERN .. trigger:gsub('.%?', '') .. ': ' .. reaction .. '\n'
-		table.insert(reactions.triggers, utilities.INVOCATION_PATTERN..trigger)
-		table.insert(reactions.triggers, utilities.INVOCATION_PATTERN..trigger..'@'..self.info.username:lower())
+		help = help .. '• ' .. utilities.CMD_PAT .. trigger:gsub('.%?', '') .. ': ' .. reaction .. '\n'
+		table.insert(reactions.triggers, utilities.CMD_PAT..trigger)
+		table.insert(reactions.triggers, utilities.CMD_PAT..trigger..'@'..self.info.username:lower())
 	end
 end
 
 function reactions:action(msg)
-	if string.match(msg.text_lower, utilities.INVOCATION_PATTERN..'reactions') then
+	if string.match(msg.text_lower, utilities.CMD_PAT..'reactions') then
 		utilities.send_message(self, msg.chat.id, help)
 		return
 	end
 	for trigger,reaction in pairs(mapping) do
-		if string.match(msg.text_lower, utilities.INVOCATION_PATTERN..trigger) then
+		if string.match(msg.text_lower, utilities.CMD_PAT..trigger) then
 			utilities.send_message(self, msg.chat.id, reaction)
 			return
 		end

--- a/plugins/reddit.lua
+++ b/plugins/reddit.lua
@@ -7,9 +7,9 @@ local utilities = require('utilities')
 
 reddit.command = 'reddit [r/subreddit | query]'
 reddit.doc = [[```
-/reddit [r/subreddit | query]
+]]..utilities.CMD_PAT..[[reddit [r/subreddit | query]
 Returns the top posts or results for a given subreddit or query. If no argument is given, returns the top posts from r/all. Querying specific subreddits is not supported.
-Aliases: /r, /r/subreddit
+Aliases: ]]..utilities.CMD_PAT..[[r, /r/subreddit
 ```]]
 
 function reddit:init()
@@ -48,7 +48,7 @@ function reddit:action(msg, config)
 	local text = msg.text_lower
 	if text:match('^/r/.') then
 		-- Normalize input so this hack works easily.
-		text = msg.text_lower:gsub('^/r/', '/r r/')
+		text = msg.text_lower:gsub('^/r/', utilities.CMD_PAT..'r r/')
 	end
 	local input = utilities.input(text)
 	local source, url

--- a/plugins/reddit.lua
+++ b/plugins/reddit.lua
@@ -39,7 +39,7 @@ reddit.subreddit_url = 'http://www.reddit.com/%s/.json?limit='
 reddit.search_url = 'http://www.reddit.com/search.json?q=%s&limit='
 reddit.rall_url = 'http://www.reddit.com/.json?limit='
 
-function reddit:action(msg)
+function reddit:action(msg, config)
 	-- Eight results in PM, four results elsewhere.
 	local limit = 4
 	if msg.chat.type == 'private' then
@@ -69,11 +69,11 @@ function reddit:action(msg)
 	end
 	local jstr, res = HTTP.request(url)
 	if res ~= 200 then
-		utilities.send_reply(self, msg, self.config.errors.connection)
+		utilities.send_reply(self, msg, config.errors.connection)
 	else
 		local jdat = JSON.decode(jstr)
 		if #jdat.data.children == 0 then
-			utilities.send_reply(self, msg, self.config.errors.results)
+			utilities.send_reply(self, msg, config.errors.results)
 		else
 			local output = format_results(jdat.data.children)
 			output = source .. output

--- a/plugins/reddit.lua
+++ b/plugins/reddit.lua
@@ -6,14 +6,14 @@ local JSON = require('dkjson')
 local utilities = require('utilities')
 
 reddit.command = 'reddit [r/subreddit | query]'
-reddit.doc = [[```
-]]..utilities.CMD_PAT..[[reddit [r/subreddit | query]
-Returns the top posts or results for a given subreddit or query. If no argument is given, returns the top posts from r/all. Querying specific subreddits is not supported.
-Aliases: ]]..utilities.CMD_PAT..[[r, /r/subreddit
-```]]
 
-function reddit:init()
-	reddit.triggers = utilities.triggers(self.info.username, {'^/r/'}):t('reddit', true):t('r', true):t('r/', true).table
+function reddit:init(config)
+	reddit.triggers = utilities.triggers(self.info.username, config.cmd_pat, {'^/r/'}):t('reddit', true):t('r', true):t('r/', true).table
+	reddit.doc = [[```
+]]..config.cmd_pat..[[reddit [r/subreddit | query]
+Returns the top posts or results for a given subreddit or query. If no argument is given, returns the top posts from r/all. Querying specific subreddits is not supported.
+Aliases: ]]..config.cmd_pat..[[r, /r/subreddit
+```]]
 end
 
 local format_results = function(posts)
@@ -48,7 +48,7 @@ function reddit:action(msg, config)
 	local text = msg.text_lower
 	if text:match('^/r/.') then
 		-- Normalize input so this hack works easily.
-		text = msg.text_lower:gsub('^/r/', utilities.CMD_PAT..'r r/')
+		text = msg.text_lower:gsub('^/r/', config.cmd_pat..'r r/')
 	end
 	local input = utilities.input(text)
 	local source, url

--- a/plugins/remind.lua
+++ b/plugins/remind.lua
@@ -4,7 +4,7 @@ local utilities = require('utilities')
 
 remind.command = 'remind <duration> <message>'
 remind.doc = [[```
-	/remind <duration> <message>
+	]]..utilities.CMD_PAT..[[remind <duration> <message>
 	Repeats a message after a duration of time, in minutes.
 	```]]
 

--- a/plugins/remind.lua
+++ b/plugins/remind.lua
@@ -3,15 +3,15 @@ local remind = {}
 local utilities = require('utilities')
 
 remind.command = 'remind <duration> <message>'
-remind.doc = [[```
-	]]..utilities.CMD_PAT..[[remind <duration> <message>
-	Repeats a message after a duration of time, in minutes.
-	```]]
 
-function remind:init()
+function remind:init(config)
 	self.database.reminders = self.database.reminders or {}
 
-	remind.triggers = utilities.triggers(self.info.username):t('remind', true).table
+	remind.triggers = utilities.triggers(self.info.username, config.cmd_pat):t('remind', true).table
+	remind.doc = [[```
+	]]..config.cmd_pat..[[remind <duration> <message>
+	Repeats a message after a duration of time, in minutes.
+	```]]
 end
 
 function remind:action(msg)

--- a/plugins/setandget.lua
+++ b/plugins/setandget.lua
@@ -9,9 +9,9 @@ end
 
 setandget.command = 'set <name> <value>'
 setandget.doc = [[```
-/set <name> <value>
-Stores a value with the given name. Use "/set <name> --" to delete the stored value.
-/get [name]
+]]..utilities.CMD_PAT..[[set <name> <value>
+Stores a value with the given name. Use "]]..utilities.CMD_PAT..[[set <name> --" to delete the stored value.
+]]..utilities.CMD_PAT..[[get [name]
 Returns the stored value or a list of stored values.
 ```]]
 
@@ -21,7 +21,7 @@ function setandget:action(msg)
 	local input = utilities.input(msg.text)
 	self.database.setandget[msg.chat.id_str] = self.database.setandget[msg.chat.id_str] or {}
 
-	if msg.text_lower:match('^/set') then
+	if msg.text_lower:match('^'..utilities.CMD_PAT..'set') then
 
 		if not input then
 			utilities.send_message(self, msg.chat.id, setandget.doc, true, nil, true)
@@ -41,7 +41,7 @@ function setandget:action(msg)
 			utilities.send_message(self, msg.chat.id, '"' .. name .. '" has been set to "' .. value .. '".', true)
 		end
 
-	elseif msg.text_lower:match('^/get') then
+	elseif msg.text_lower:match('^'..utilities.CMD_PAT..'get') then
 
 		if not input then
 			local output

--- a/plugins/setandget.lua
+++ b/plugins/setandget.lua
@@ -2,26 +2,25 @@ local setandget = {}
 
 local utilities = require('utilities')
 
-function setandget:init()
+function setandget:init(config)
 	self.database.setandget = self.database.setandget or {}
-	setandget.triggers = utilities.triggers(self.info.username):t('set', true):t('get', true).table
+	setandget.triggers = utilities.triggers(self.info.username, config.cmd_pat):t('set', true):t('get', true).table
+	setandget.doc = [[```
+]]..config.cmd_pat..[[set <name> <value>
+Stores a value with the given name. Use "]]..config.cmd_pat..[[set <name> --" to delete the stored value.
+]]..config.cmd_pat..[[get [name]
+Returns the stored value or a list of stored values.
+```]]
 end
 
 setandget.command = 'set <name> <value>'
-setandget.doc = [[```
-]]..utilities.CMD_PAT..[[set <name> <value>
-Stores a value with the given name. Use "]]..utilities.CMD_PAT..[[set <name> --" to delete the stored value.
-]]..utilities.CMD_PAT..[[get [name]
-Returns the stored value or a list of stored values.
-```]]
 
-
-function setandget:action(msg)
+function setandget:action(msg, config)
 
 	local input = utilities.input(msg.text)
 	self.database.setandget[msg.chat.id_str] = self.database.setandget[msg.chat.id_str] or {}
 
-	if msg.text_lower:match('^'..utilities.CMD_PAT..'set') then
+	if msg.text_lower:match('^'..config.cmd_pat..'set') then
 
 		if not input then
 			utilities.send_message(self, msg.chat.id, setandget.doc, true, nil, true)
@@ -41,7 +40,7 @@ function setandget:action(msg)
 			utilities.send_message(self, msg.chat.id, '"' .. name .. '" has been set to "' .. value .. '".', true)
 		end
 
-	elseif msg.text_lower:match('^'..utilities.CMD_PAT..'get') then
+	elseif msg.text_lower:match('^'..config.cmd_pat..'get') then
 
 		if not input then
 			local output

--- a/plugins/shell.lua
+++ b/plugins/shell.lua
@@ -6,9 +6,9 @@ function shell:init()
 	shell.triggers = utilities.triggers(self.info.username):t('run', true).table
 end
 
-function shell:action(msg)
+function shell:action(msg, config)
 
-	if msg.from.id ~= self.config.admin then
+	if msg.from.id ~= config.admin then
 		return
 	end
 

--- a/plugins/shell.lua
+++ b/plugins/shell.lua
@@ -2,8 +2,8 @@ local shell = {}
 
 local utilities = require('utilities')
 
-function shell:init()
-	shell.triggers = utilities.triggers(self.info.username):t('run', true).table
+function shell:init(config)
+	shell.triggers = utilities.triggers(self.info.username, config.cmd_pat):t('run', true).table
 end
 
 function shell:action(msg, config)

--- a/plugins/shout.lua
+++ b/plugins/shout.lua
@@ -3,13 +3,13 @@ local shout = {}
 local utilities = require('utilities')
 
 shout.command = 'shout <text>'
-shout.doc = [[```
-]]..utilities.CMD_PAT..[[shout <text>
+
+function shout:init(config)
+	shout.triggers = utilities.triggers(self.info.username, config.cmd_pat):t('shout', true).table
+	shout.doc = [[```
+]]..config.CMD_PAT..[[shout <text>
 Shouts something. Input may be the replied-to message.
 ```]]
-
-function shout:init()
-	shout.triggers = utilities.triggers(self.info.username):t('shout', true).table
 end
 
 function shout:action(msg)

--- a/plugins/shout.lua
+++ b/plugins/shout.lua
@@ -4,7 +4,7 @@ local utilities = require('utilities')
 
 shout.command = 'shout <text>'
 shout.doc = [[```
-/shout <text>
+]]..utilities.CMD_PAT..[[shout <text>
 Shouts something. Input may be the replied-to message.
 ```]]
 

--- a/plugins/slap.lua
+++ b/plugins/slap.lua
@@ -4,7 +4,7 @@ local utilities = require('utilities')
 
 slap.command = 'slap [target]'
 slap.doc = [[```
-/slap [target]
+]]..utilities.CMD_PAT..[[slap [target]
 Slap somebody.
 ```]]
 

--- a/plugins/slap.lua
+++ b/plugins/slap.lua
@@ -3,13 +3,13 @@ local slap = {}
 local utilities = require('utilities')
 
 slap.command = 'slap [target]'
-slap.doc = [[```
-]]..utilities.CMD_PAT..[[slap [target]
+
+function slap:init(config)
+	slap.triggers = utilities.triggers(self.info.username, config.cmd_pat):t('slap', true).table
+	slap.doc = [[```
+]]..config.cmd_pat..[[slap [target]
 Slap somebody.
 ```]]
-
-function slap:init()
-	slap.triggers = utilities.triggers(self.info.username):t('slap', true).table
 end
 
 local slaps = {

--- a/plugins/time.lua
+++ b/plugins/time.lua
@@ -6,7 +6,7 @@ local utilities = require('utilities')
 
 time.command = 'time <location>'
 time.doc = [[```
-/time <location>
+]]..utilities.CMD_PAT..[[time <location>
 Returns the time, date, and timezone for the given location.
 ```]]
 
@@ -26,7 +26,7 @@ function time:action(msg, config)
 		end
 	end
 
-	local coords = utilities.get_coords(self, input, config)
+	local coords = utilities.get_coords(input, config)
 	if type(coords) == 'string' then
 		utilities.send_reply(self, msg, coords)
 		return

--- a/plugins/time.lua
+++ b/plugins/time.lua
@@ -14,7 +14,7 @@ function time:init()
 	time.triggers = utilities.triggers(self.info.username):t('time', true).table
 end
 
-function time:action(msg)
+function time:action(msg, config)
 
 	local input = utilities.input(msg.text)
 	if not input then
@@ -26,7 +26,7 @@ function time:action(msg)
 		end
 	end
 
-	local coords = utilities.get_coords(self, input)
+	local coords = utilities.get_coords(self, input, config)
 	if type(coords) == 'string' then
 		utilities.send_reply(self, msg, coords)
 		return
@@ -39,7 +39,7 @@ function time:action(msg)
 
 	local jstr, res = HTTPS.request(url)
 	if res ~= 200 then
-		utilities.send_reply(self, msg, self.config.errors.connection)
+		utilities.send_reply(self, msg, config.errors.connection)
 		return
 	end
 

--- a/plugins/time.lua
+++ b/plugins/time.lua
@@ -5,13 +5,13 @@ local JSON = require('dkjson')
 local utilities = require('utilities')
 
 time.command = 'time <location>'
-time.doc = [[```
-]]..utilities.CMD_PAT..[[time <location>
+
+function time:init(config)
+	time.triggers = utilities.triggers(self.info.username, config.cmd_pat):t('time', true).table
+	time.doc = [[```
+]]..config.cmd_pat..[[time <location>
 Returns the time, date, and timezone for the given location.
 ```]]
-
-function time:init()
-	time.triggers = utilities.triggers(self.info.username):t('time', true).table
 end
 
 function time:action(msg, config)

--- a/plugins/translate.lua
+++ b/plugins/translate.lua
@@ -7,7 +7,7 @@ local utilities = require('utilities')
 
 translate.command = 'translate [text]'
 translate.doc = [[```
-/translate [text]
+]]..utilities.CMD_PAT..[[translate [text]
 Translates input or the replied-to message into the bot's language.
 ```]]
 

--- a/plugins/translate.lua
+++ b/plugins/translate.lua
@@ -15,7 +15,7 @@ function translate:init()
 	translate.triggers = utilities.triggers(self.info.username):t('translate', true):t('tl', true).table
 end
 
-function translate:action(msg)
+function translate:action(msg, config)
 
 	local input = utilities.input(msg.text)
 	if not input then
@@ -27,17 +27,17 @@ function translate:action(msg)
 		end
 	end
 
-	local url = 'https://translate.yandex.net/api/v1.5/tr.json/translate?key=' .. self.config.yandex_key .. '&lang=' .. self.config.lang .. '&text=' .. URL.escape(input)
+	local url = 'https://translate.yandex.net/api/v1.5/tr.json/translate?key=' .. config.yandex_key .. '&lang=' .. config.lang .. '&text=' .. URL.escape(input)
 
 	local str, res = HTTPS.request(url)
 	if res ~= 200 then
-		utilities.send_reply(self, msg, self.config.errors.connection)
+		utilities.send_reply(self, msg, config.errors.connection)
 		return
 	end
 
 	local jdat = JSON.decode(str)
 	if jdat.code ~= 200 then
-		utilities.send_reply(self, msg, self.config.errors.connection)
+		utilities.send_reply(self, msg, config.errors.connection)
 		return
 	end
 

--- a/plugins/translate.lua
+++ b/plugins/translate.lua
@@ -6,13 +6,13 @@ local JSON = require('dkjson')
 local utilities = require('utilities')
 
 translate.command = 'translate [text]'
-translate.doc = [[```
-]]..utilities.CMD_PAT..[[translate [text]
+
+function translate:init(config)
+	translate.triggers = utilities.triggers(self.info.username, config.cmd_pat):t('translate', true):t('tl', true).table
+	translate.doc = [[```
+]]..config.cmd_pat..[[translate [text]
 Translates input or the replied-to message into the bot's language.
 ```]]
-
-function translate:init()
-	translate.triggers = utilities.triggers(self.info.username):t('translate', true):t('tl', true).table
 end
 
 function translate:action(msg, config)

--- a/plugins/urbandictionary.lua
+++ b/plugins/urbandictionary.lua
@@ -6,14 +6,15 @@ local JSON = require('dkjson')
 local utilities = require('utilities')
 
 urbandictionary.command = 'urbandictionary <query>'
-urbandictionary.doc = [[```
-]]..utilities.CMD_PAT..[[urbandictionary <query>
-Returns a definition from Urban Dictionary.
-Aliases: ]]..utilities.CMD_PAT..[[ud, ]]..utilities.CMD_PAT..[[urban
-```]]
 
-function urbandictionary:init()
-	urbandictionary.triggers = utilities.triggers(self.info.username):t('urbandictionary', true):t('ud', true):t('urban', true).table
+function urbandictionary:init(config)
+	urbandictionary.triggers = utilities.triggers(self.info.username, config.cmd_pat)
+		:t('urbandictionary', true):t('ud', true):t('urban', true).table
+	urbandictionary.doc = [[```
+]]..config.cmd_pat..[[urbandictionary <query>
+Returns a definition from Urban Dictionary.
+Aliases: ]]..config.cmd_pat..[[ud, ]]..config.cmd_pat..[[urban
+```]]
 end
 
 function urbandictionary:action(msg, config)

--- a/plugins/urbandictionary.lua
+++ b/plugins/urbandictionary.lua
@@ -7,9 +7,9 @@ local utilities = require('utilities')
 
 urbandictionary.command = 'urbandictionary <query>'
 urbandictionary.doc = [[```
-/urbandictionary <query>
+]]..utilities.CMD_PAT..[[urbandictionary <query>
 Returns a definition from Urban Dictionary.
-Aliases: /ud, /urban
+Aliases: ]]..utilities.CMD_PAT..[[ud, ]]..utilities.CMD_PAT..[[urban
 ```]]
 
 function urbandictionary:init()

--- a/plugins/urbandictionary.lua
+++ b/plugins/urbandictionary.lua
@@ -16,7 +16,7 @@ function urbandictionary:init()
 	urbandictionary.triggers = utilities.triggers(self.info.username):t('urbandictionary', true):t('ud', true):t('urban', true).table
 end
 
-function urbandictionary:action(msg)
+function urbandictionary:action(msg, config)
 
 	local input = utilities.input(msg.text)
 	if not input then
@@ -32,13 +32,13 @@ function urbandictionary:action(msg)
 
 	local jstr, res = HTTP.request(url)
 	if res ~= 200 then
-		utilities.send_reply(self, msg, self.config.errors.connection)
+		utilities.send_reply(self, msg, config.errors.connection)
 		return
 	end
 
 	local jdat = JSON.decode(jstr)
 	if jdat.result_type == "no_results" then
-		utilities.send_reply(self, msg, self.config.errors.results)
+		utilities.send_reply(self, msg, config.errors.results)
 		return
 	end
 

--- a/plugins/weather.lua
+++ b/plugins/weather.lua
@@ -16,7 +16,7 @@ end
 
 weather.command = 'weather <location>'
 weather.doc = [[```
-/weather <location>
+]]..utilities.CMD_PAT..[[weather <location>
 Returns the current weather conditions for a given location.
 ```]]
 
@@ -32,7 +32,7 @@ function weather:action(msg, config)
 		end
 	end
 
-	local coords = utilities.get_coords(self, input, config)
+	local coords = utilities.get_coords(input, config)
 	if type(coords) == 'string' then
 		utilities.send_reply(self, msg, coords)
 		return

--- a/plugins/weather.lua
+++ b/plugins/weather.lua
@@ -4,8 +4,8 @@ local HTTP = require('socket.http')
 local JSON = require('dkjson')
 local utilities = require('utilities')
 
-function weather:init()
-	if not self.config.owm_api_key then
+function weather:init(config)
+	if not config.owm_api_key then
 		print('Missing config value: owm_api_key.')
 		print('weather.lua will not be enabled.')
 		return
@@ -20,7 +20,7 @@ weather.doc = [[```
 Returns the current weather conditions for a given location.
 ```]]
 
-function weather:action(msg)
+function weather:action(msg, config)
 
 	local input = utilities.input(msg.text)
 	if not input then
@@ -32,17 +32,17 @@ function weather:action(msg)
 		end
 	end
 
-	local coords = utilities.get_coords(self, input)
+	local coords = utilities.get_coords(self, input, config)
 	if type(coords) == 'string' then
 		utilities.send_reply(self, msg, coords)
 		return
 	end
 
-	local url = 'http://api.openweathermap.org/data/2.5/weather?APPID=' .. self.config.owm_api_key .. '&lat=' .. coords.lat .. '&lon=' .. coords.lon
+	local url = 'http://api.openweathermap.org/data/2.5/weather?APPID=' .. config.owm_api_key .. '&lat=' .. coords.lat .. '&lon=' .. coords.lon
 
 	local jstr, res = HTTP.request(url)
 	if res ~= 200 then
-		utilities.send_reply(self, msg, self.config.errors.connection)
+		utilities.send_reply(self, msg, config.errors.connection)
 		return
 	end
 

--- a/plugins/weather.lua
+++ b/plugins/weather.lua
@@ -11,14 +11,14 @@ function weather:init(config)
 		return
 	end
 
-	weather.triggers = utilities.triggers(self.info.username):t('weather', true).table
+	weather.triggers = utilities.triggers(self.info.username, config.cmd_pat):t('weather', true).table
+	weather.doc = [[```
+]]..config.cmd_pat..[[weather <location>
+Returns the current weather conditions for a given location.
+```]]
 end
 
 weather.command = 'weather <location>'
-weather.doc = [[```
-]]..utilities.CMD_PAT..[[weather <location>
-Returns the current weather conditions for a given location.
-```]]
 
 function weather:action(msg, config)
 

--- a/plugins/whoami.lua
+++ b/plugins/whoami.lua
@@ -5,7 +5,7 @@ local utilities = require('utilities')
 whoami.command = 'whoami'
 whoami.doc = [[```
 Returns user and chat info for you or the replied-to message.
-Alias: /who
+Alias: ]]..utilities.CMD_PAT..[[who
 ```]]
 
 function whoami:init()

--- a/plugins/whoami.lua
+++ b/plugins/whoami.lua
@@ -3,13 +3,13 @@ local whoami = {}
 local utilities = require('utilities')
 
 whoami.command = 'whoami'
-whoami.doc = [[```
-Returns user and chat info for you or the replied-to message.
-Alias: ]]..utilities.CMD_PAT..[[who
-```]]
 
-function whoami:init()
-	whoami.triggers = utilities.triggers(self.info.username):t('who', true):t('whoami').table
+function whoami:init(config)
+	whoami.triggers = utilities.triggers(self.info.username, config.cmd_pat):t('who', true):t('whoami').table
+	whoami.doc = [[```
+Returns user and chat info for you or the replied-to message.
+Alias: ]]..config.cmd_pat..[[who
+```]]
 end
 
 function whoami:action(msg)

--- a/plugins/wikipedia.lua
+++ b/plugins/wikipedia.lua
@@ -6,14 +6,14 @@ local JSON = require('dkjson')
 local utilities = require('utilities')
 
 wikipedia.command = 'wikipedia <query>'
-wikipedia.doc = [[```
-]]..utilities.CMD_PAT..[[wikipedia <query>
-Returns an article from Wikipedia.
-Aliases: ]]..utilities.CMD_PAT..[[w, ]]..utilities.CMD_PAT..[[wiki
-```]]
 
-function wikipedia:init()
-	wikipedia.triggers = utilities.triggers(self.info.username):t('wikipedia', true):t('wiki', true):t('w', true).table
+function wikipedia:init(config)
+	wikipedia.triggers = utilities.triggers(self.info.username, config.cmd_pat):t('wikipedia', true):t('wiki', true):t('w', true).table
+	wikipedia.doc = [[```
+]]..config.cmd_pat..[[wikipedia <query>
+Returns an article from Wikipedia.
+Aliases: ]]..config.cmd_pat..[[w, ]]..config.cmd_pat..[[wiki
+```]]
 end
 
 local get_title = function(search)

--- a/plugins/wikipedia.lua
+++ b/plugins/wikipedia.lua
@@ -25,7 +25,7 @@ local get_title = function(search)
 	return false
 end
 
-function wikipedia:action(msg)
+function wikipedia:action(msg, config)
 
 	-- Get the query. If it's not in the message, check the replied-to message.
 	-- If those don't exist, send the help text.
@@ -50,19 +50,19 @@ function wikipedia:action(msg)
 
 	jstr, res = HTTPS.request(search_url .. URL.escape(input))
 	if res ~= 200 then
-		utilities.send_reply(self, msg, self.config.errors.connection)
+		utilities.send_reply(self, msg, config.errors.connection)
 		return
 	end
 
 	jdat = JSON.decode(jstr)
 	if jdat.query.searchinfo.totalhits == 0 then
-		utilities.send_reply(self, msg, self.config.errors.results)
+		utilities.send_reply(self, msg, config.errors.results)
 		return
 	end
 
 	local title = get_title(jdat.query.search)
 	if not title then
-		utilities.send_reply(self, msg, self.config.errors.results)
+		utilities.send_reply(self, msg, config.errors.results)
 		return
 	end
 
@@ -70,7 +70,7 @@ function wikipedia:action(msg)
 
 	jstr, res = HTTPS.request(res_url .. URL.escape(title))
 	if res ~= 200 then
-		utilities.send_reply(self, msg, self.config.errors.connection)
+		utilities.send_reply(self, msg, config.errors.connection)
 		return
 	end
 
@@ -78,7 +78,7 @@ function wikipedia:action(msg)
 	local text = JSON.decode(jstr).query.pages
 	_, text = next(text)
 	if not text then
-		utilities.send_reply(self, msg, self.config.errors.results)
+		utilities.send_reply(self, msg, config.errors.results)
 		return
 	else
 		text = text.extract

--- a/plugins/wikipedia.lua
+++ b/plugins/wikipedia.lua
@@ -7,9 +7,9 @@ local utilities = require('utilities')
 
 wikipedia.command = 'wikipedia <query>'
 wikipedia.doc = [[```
-/wikipedia <query>
+]]..utilities.CMD_PAT..[[wikipedia <query>
 Returns an article from Wikipedia.
-Aliases: /w, /wiki
+Aliases: ]]..utilities.CMD_PAT..[[w, ]]..utilities.CMD_PAT..[[wiki
 ```]]
 
 function wikipedia:init()

--- a/plugins/xkcd.lua
+++ b/plugins/xkcd.lua
@@ -6,7 +6,7 @@ local utilities = require('utilities')
 
 xkcd.command = 'xkcd [i]'
 xkcd.doc = [[```
-/xkcd [i]
+]]..utilities.CMD_PAT..[[xkcd [i]
 Returns the latest xkcd strip and its alt text. If a number is given, returns that number strip. If "r" is passed in place of a number, returns a random strip.
 ```]]
 

--- a/plugins/xkcd.lua
+++ b/plugins/xkcd.lua
@@ -14,11 +14,11 @@ function xkcd:init()
 	xkcd.triggers = utilities.triggers(self.info.username):t('xkcd', true).table
 end
 
-function xkcd:action(msg)
+function xkcd:action(msg, config)
 
 	local jstr, res = HTTP.request('http://xkcd.com/info.0.json')
 	if res ~= 200 then
-		utilities.send_reply(self, msg, self.config.errors.connection)
+		utilities.send_reply(self, msg, config.errors.connection)
 		return
 	end
 	local latest = JSON.decode(jstr).num
@@ -44,7 +44,7 @@ function xkcd:action(msg)
 
 	jstr, res = HTTP.request(res_url)
 	if res ~= 200 then
-		utilities.send_reply(self, msg, self.config.errors.connection)
+		utilities.send_reply(self, msg, config.errors.connection)
 		return
 	end
 	local jdat = JSON.decode(jstr)

--- a/plugins/xkcd.lua
+++ b/plugins/xkcd.lua
@@ -5,13 +5,13 @@ local JSON = require('dkjson')
 local utilities = require('utilities')
 
 xkcd.command = 'xkcd [i]'
-xkcd.doc = [[```
-]]..utilities.CMD_PAT..[[xkcd [i]
+
+function xkcd:init(config)
+	xkcd.triggers = utilities.triggers(self.info.username, config.cmd_pat):t('xkcd', true).table
+	xkcd.doc = [[```
+]]..config.cmd_pat..[[xkcd [i]
 Returns the latest xkcd strip and its alt text. If a number is given, returns that number strip. If "r" is passed in place of a number, returns a random strip.
 ```]]
-
-function xkcd:init()
-	xkcd.triggers = utilities.triggers(self.info.username):t('xkcd', true).table
 end
 
 function xkcd:action(msg, config)

--- a/plugins/youtube.lua
+++ b/plugins/youtube.lua
@@ -19,9 +19,9 @@ end
 
 youtube.command = 'youtube <query>'
 youtube.doc = [[```
-/youtube <query>
+]]..utilities.CMD_PAT..[[youtube <query>
 Returns the top result from YouTube.
-Alias: /yt
+Alias: ]]..utilities.CMD_PAT..[[yt
 ```]]
 
 function youtube:action(msg, config)

--- a/plugins/youtube.lua
+++ b/plugins/youtube.lua
@@ -7,8 +7,8 @@ local URL = require('socket.url')
 local JSON = require('dkjson')
 local utilities = require('utilities')
 
-function youtube:init()
-	if not self.config.google_api_key then
+function youtube:init(config)
+	if not config.google_api_key then
 		print('Missing config value: google_api_key.')
 		print('youtube.lua will not be enabled.')
 		return
@@ -24,7 +24,7 @@ Returns the top result from YouTube.
 Alias: /yt
 ```]]
 
-function youtube:action(msg)
+function youtube:action(msg, config)
 
 	local input = utilities.input(msg.text)
 	if not input then
@@ -36,17 +36,17 @@ function youtube:action(msg)
 		end
 	end
 
-	local url = 'https://www.googleapis.com/youtube/v3/search?key=' .. self.config.google_api_key .. '&type=video&part=snippet&maxResults=4&q=' .. URL.escape(input)
+	local url = 'https://www.googleapis.com/youtube/v3/search?key=' .. config.google_api_key .. '&type=video&part=snippet&maxResults=4&q=' .. URL.escape(input)
 
 	local jstr, res = HTTPS.request(url)
 	if res ~= 200 then
-		utilities.send_reply(self, msg, self.config.errors.connection)
+		utilities.send_reply(self, msg, config.errors.connection)
 		return
 	end
 
 	local jdat = JSON.decode(jstr)
 	if jdat.pageInfo.totalResults == 0 then
-		utilities.send_reply(self, msg, self.config.errors.results)
+		utilities.send_reply(self, msg, config.errors.results)
 		return
 	end
 

--- a/plugins/youtube.lua
+++ b/plugins/youtube.lua
@@ -14,15 +14,15 @@ function youtube:init(config)
 		return
 	end
 
-	youtube.triggers = utilities.triggers(self.info.username):t('youtube', true):t('yt', true).table
+	youtube.triggers = utilities.triggers(self.info.username, config.cmd_pat):t('youtube', true):t('yt', true).table
+	youtube.doc = [[```
+]]..config.cmd_pat..[[youtube <query>
+Returns the top result from YouTube.
+Alias: ]]..config.cmd_pat..[[yt
+```]]
 end
 
 youtube.command = 'youtube <query>'
-youtube.doc = [[```
-]]..utilities.CMD_PAT..[[youtube <query>
-Returns the top result from YouTube.
-Alias: ]]..utilities.CMD_PAT..[[yt
-```]]
 
 function youtube:action(msg, config)
 

--- a/utilities.lua
+++ b/utilities.lua
@@ -281,24 +281,23 @@ end
 
 utilities.md_escape = utilities.markdown_escape
 
-utilities.CMD_PAT = '/'
-
 utilities.triggers_meta = {}
 utilities.triggers_meta.__index = utilities.triggers_meta
 function utilities.triggers_meta:t(pattern, has_args)
 	local username = self.username:lower()
-	table.insert(self.table, '^'..utilities.CMD_PAT..pattern..'$')
-	table.insert(self.table, '^'..utilities.CMD_PAT..pattern..'@'..username..'$')
+	table.insert(self.table, '^'..self.cmd_pat..pattern..'$')
+	table.insert(self.table, '^'..self.cmd_pat..pattern..'@'..username..'$')
 	if has_args then
-		table.insert(self.table, '^'..utilities.CMD_PAT..pattern..'%s+[^%s]*')
-		table.insert(self.table, '^'..utilities.CMD_PAT..pattern..'@'..username..'%s+[^%s]*')
+		table.insert(self.table, '^'..self.cmd_pat..pattern..'%s+[^%s]*')
+		table.insert(self.table, '^'..self.cmd_pat..pattern..'@'..username..'%s+[^%s]*')
 	end
 	return self
 end
 
-function utilities.triggers(username, trigger_table)
+function utilities.triggers(username, cmd_pat, trigger_table)
 	local self = setmetatable({}, utilities.triggers_meta)
 	self.username = username
+	self.cmd_pat = cmd_pat
 	self.table = trigger_table or {}
 	return self
 end

--- a/utilities.lua
+++ b/utilities.lua
@@ -137,7 +137,7 @@ function utilities.save_data(filename, data)
 end
 
  -- Gets coordinates for a location. Used by gMaps.lua, time.lua, weather.lua.
-function utilities:get_coords(input, config)
+function utilities.get_coords(input, config)
 
 	local url = 'http://maps.googleapis.com/maps/api/geocode/json?address=' .. URL.escape(input)
 
@@ -281,17 +281,17 @@ end
 
 utilities.md_escape = utilities.markdown_escape
 
-utilities.INVOCATION_PATTERN = '/'
+utilities.CMD_PAT = '/'
 
 utilities.triggers_meta = {}
 utilities.triggers_meta.__index = utilities.triggers_meta
 function utilities.triggers_meta:t(pattern, has_args)
 	local username = self.username:lower()
-	table.insert(self.table, '^'..utilities.INVOCATION_PATTERN..pattern..'$')
-	table.insert(self.table, '^'..utilities.INVOCATION_PATTERN..pattern..'@'..username..'$')
+	table.insert(self.table, '^'..utilities.CMD_PAT..pattern..'$')
+	table.insert(self.table, '^'..utilities.CMD_PAT..pattern..'@'..username..'$')
 	if has_args then
-		table.insert(self.table, '^'..utilities.INVOCATION_PATTERN..pattern..'%s+[^%s]*')
-		table.insert(self.table, '^'..utilities.INVOCATION_PATTERN..pattern..'@'..username..'%s+[^%s]*')
+		table.insert(self.table, '^'..utilities.CMD_PAT..pattern..'%s+[^%s]*')
+		table.insert(self.table, '^'..utilities.CMD_PAT..pattern..'@'..username..'%s+[^%s]*')
 	end
 	return self
 end

--- a/utilities.lua
+++ b/utilities.lua
@@ -137,18 +137,18 @@ function utilities.save_data(filename, data)
 end
 
  -- Gets coordinates for a location. Used by gMaps.lua, time.lua, weather.lua.
-function utilities:get_coords(input)
+function utilities:get_coords(input, config)
 
 	local url = 'http://maps.googleapis.com/maps/api/geocode/json?address=' .. URL.escape(input)
 
 	local jstr, res = HTTP.request(url)
 	if res ~= 200 then
-		return self.config.errors.connection
+		return config.errors.connection
 	end
 
 	local jdat = JSON.decode(jstr)
 	if jdat.status == 'ZERO_RESULTS' then
-		return self.config.errors.results
+		return config.errors.results
 	end
 
 	return {
@@ -231,15 +231,15 @@ function utilities:user_from_message(msg, no_extra)
 
 end
 
-function utilities:handle_exception(err, message)
+function utilities:handle_exception(err, message, config)
 
 	if not err then err = '' end
 
 	local output = '\n[' .. os.date('%F %T', os.time()) .. ']\n' .. self.info.username .. ': ' .. err .. '\n' .. message .. '\n'
 
-	if self.config.log_chat then
+	if config.log_chat then
 		output = '```' .. output .. '```'
-		utilities.send_message(self, self.config.log_chat, output, true, nil, true)
+		utilities.send_message(self, config.log_chat, output, true, nil, true)
 	else
 		print(output)
 	end


### PR DESCRIPTION
This PR does two main things: it makes obvious whenever stable config values are used (self is more of a transient thing IMHO) and allows for more complex config behavior (e.g. a metatable frontend to a non-Lua table backend) without mucking around as much with internal bot behavior. We know `config` is not being changed behind our backs, and thus possibly messing up non-standard setups. Also included is a proper change to `config.cmd_pat` ~~(still in `utilities`, as I haven't decided on a good way to move it to `config` yet)~~ everywhere, allowing a universal change of command prefix live with reload from your config.