### PR TITLE
Unicode support for length checking in /nick

### DIFF
--- a/plugins/nick.lua
+++ b/plugins/nick.lua
@@ -34,7 +34,7 @@ function nick:action(msg)
 		else
 			output = target.name .. ' currently has no nickname.'
 		end
-	elseif string.len(input) > 32 then
+	elseif utilities.utf8_len(input) > 32 then
 		output = 'The character limit for nicknames is 32.'
 	elseif input == '--' or input == utilities.char.em_dash then
 		self.database.users[target.id_str].nickname = nil

--- a/utilities.lua
+++ b/utilities.lua
@@ -39,6 +39,18 @@ function utilities.input(s)
 	return s:sub(s:find(' ')+1)
 end
 
+-- Calculates the length of the given string as UTF-8 characters
+function utilities.utf8_len(s)
+    local chars = 0
+    for i = 1, string.len(s) do
+        local b = string.byte(s, i)
+        if b < 128 or b >= 192 then
+            chars = chars + 1
+        end
+    end
+    return chars
+end
+
  -- I swear, I copied this from PIL, not yago! :)
 function utilities.trim(str) -- Trims whitespace from a string.
 	local s = str:gsub('^%s*(.-)%s*$', '%1')


### PR DESCRIPTION
self-explanatory.

UTF-8 length function also added to utilities.lua, so that it can be used in other functions where necessary.