### PR TITLE
antisquig++: Braille pattern blank illegal in name

### DIFF
--- a/otouto/plugins/administration.lua
+++ b/otouto/plugins/administration.lua
@@ -386,6 +386,8 @@ function administration.init_command(self_)
                         from_name:match(utilities.char.arabic)
                         or from_name:match(utilities.char.rtl_override)
                         or from_name:match(utilities.char.rtl_mark)
+                        or from_name:match('^'..utilities.char.braille_space)
+                        or from_name:match(utilities.char.braille_space..'$')
                     ) then
                         user.do_kick = true
                         user.reason = 'antisquig++'

--- a/otouto/utilities.lua
+++ b/otouto/utilities.lua
@@ -258,6 +258,7 @@ utilities.char = {
     rtl_mark = '‏',
     em_dash = '—',
     utf_8 = '[%z\1-\127\194-\244][\128-\191]',
+    braille_space = '⠀',
 }
 
 utilities.set_meta = {}


### PR DESCRIPTION
It can be used to extend name size to annoying sizes, as Telegram
doesn't truncate it like normal a space.