### PR TITLE
Properly detect excessive whitespace in names

### DIFF
--- a/otouto/plugins/administration.lua
+++ b/otouto/plugins/administration.lua
@@ -430,12 +430,12 @@ function administration.init_command(self_)
                         from_name:match(utilities.char.arabic)
                         or from_name:match(utilities.char.rtl_override)
                         or from_name:match(utilities.char.rtl_mark)
-                        or from_name:match('^'..utilities.char.braille_space)
-                        or from_name:match(utilities.char.braille_space..'$')
-                        or from_name:match('^'..utilities.char.invisible_separator)
-                        or from_name:match(utilities.char.invisible_separator..'$')
-                        or from_name:match('^'..utilities.char.zwnj)
-                        or from_name:match(utilities.char.zwnj..'$')
+                        -- excessive space detection
+                        or from_name:match('[ '..
+                            utilities.char.braille_space..utilities.char.invisible_separator..utilities.char.zwnj..'][ '
+                            utilities.char.braille_space..utilities.char.invisible_separator..utilities.char.zwnj..']')
+                        or from_name:match('^['..utilities.char.braille_space..utilities.char.invisible_separator..utilities.char.zwnj..']')
+                        or from_name:match('['..utilities.char.braille_space..utilities.char.invisible_separator..utilities.char.zwnj..']$')
                     ) then
                         user.do_kick = true
                         user.reason = 'antisquig++'


### PR DESCRIPTION
The issue with the previous patterns was that they only checked the beginning and end of names, in an attempt to allow for actual usage (e.g. a Braille name) to work. However, this doesn't work when it's in the middle of a name and just spammed a lot. The space patterns are now consolidated and should detect any combination trying to be annoying.