### PR TITLE
[administration] Catch bots with non-lowercase prefixes

### DIFF
--- a/otouto/plugins/administration.lua
+++ b/otouto/plugins/administration.lua
@@ -540,7 +540,7 @@ function administration.init_command(self_)
                         elseif ( -- antibot
                             group.flags[4]
                             and noob.username
-                            and noob.username:match('bot$')
+                            and noob.username:match('[Bb][Oo][Tt]$')
                             and rank < 2
                         ) then
                             new_user.do_kick = true


### PR DESCRIPTION
Marvel at Lua patterns as they don't have a case insensitive option