### PR TITLE
Add Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,16 +5,14 @@ FROM alpine:3.7
 
 RUN apk --no-cache add \
     curl gcc libc-dev pcre-dev libressl-dev \
-    lua5.3 lua5.3-dev luarocks5.3
-
-RUN luarocks-5.3 install dkjson && \
+    lua5.3 lua5.3-dev luarocks5.3 && \
+    luarocks-5.3 install dkjson && \
     luarocks-5.3 install lpeg && \
     luarocks-5.3 install lrexlib-pcre && \
     luarocks-5.3 install luasec && \
     luarocks-5.3 install luasocket && \
-    luarocks-5.3 install multipart-post
-
-RUN apk del curl gcc libc-dev pcre-dev libressl-dev lua5.3-dev
+    luarocks-5.3 install multipart-post && \
+    apk del curl gcc libc-dev pcre-dev libressl-dev lua5.3-dev
 
 COPY . /otouto
 WORKDIR /otouto

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 # Set OTOUTO_BOT_API_KEY to your telegram bot api key
 # Set ADMIN_ID to your telegram id
+# Example: docker run -e OTOUTO_BOT_API_KEY="apikeyhere" -e ADMIN_ID="idhere" jacobamason/otouto
 FROM alpine:3.7
 
-RUN apk update && apk add \
+RUN apk --no-cache add \
     curl gcc libc-dev pcre-dev libressl-dev \
     lua5.3 lua5.3-dev luarocks5.3
 
@@ -12,6 +13,8 @@ RUN luarocks-5.3 install dkjson && \
     luarocks-5.3 install luasec && \
     luarocks-5.3 install luasocket && \
     luarocks-5.3 install multipart-post
+
+RUN apk del curl gcc libc-dev pcre-dev libressl-dev lua5.3-dev
 
 COPY . /otouto
 WORKDIR /otouto

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+# Set OTOUTO_BOT_API_KEY to your telegram bot api key
+# Set ADMIN_ID to your telegram id
+FROM ubuntu:xenial
+
+RUN apt-get update && apt-get install -y \
+    sudo \
+    build-essential \
+    git \
+    libssl-dev \
+    libc6 \
+    libpcre3-dev \
+    lsb-release \
+    curl \
+    unzip
+
+COPY . /otouto
+
+WORKDIR /otouto
+
+RUN ./install-dependencies.sh
+
+CMD ./launch.sh
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,16 +3,16 @@
 # Example: docker run -e OTOUTO_BOT_API_KEY="apikeyhere" -e ADMIN_ID="idhere" jacobamason/otouto
 FROM alpine:3.7
 
-RUN apk --no-cache add \
-    curl gcc libc-dev pcre-dev libressl-dev \
-    lua5.3 lua5.3-dev luarocks5.3 && \
+RUN apk --no-cache add --virtual build-deps \
+    curl gcc libc-dev pcre-dev libressl-dev && \
+    apk --no-cache add lua5.3 lua5.3-dev luarocks5.3 && \
     luarocks-5.3 install dkjson && \
     luarocks-5.3 install lpeg && \
     luarocks-5.3 install lrexlib-pcre && \
     luarocks-5.3 install luasec && \
     luarocks-5.3 install luasocket && \
     luarocks-5.3 install multipart-post && \
-    apk del curl gcc libc-dev pcre-dev libressl-dev lua5.3-dev
+    apk del build-deps
 
 COPY . /otouto
 WORKDIR /otouto

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,19 @@
 # Set OTOUTO_BOT_API_KEY to your telegram bot api key
 # Set ADMIN_ID to your telegram id
-FROM ubuntu:xenial
+FROM alpine:3.7
 
-RUN apt-get update && apt-get install -y \
-    sudo \
-    build-essential \
-    git \
-    libssl-dev \
-    libc6 \
-    libpcre3-dev \
-    lsb-release \
-    curl \
-    unzip
+RUN apk update && apk add \
+    curl gcc libc-dev pcre-dev libressl-dev \
+    lua5.3 lua5.3-dev luarocks5.3
+
+RUN luarocks-5.3 install dkjson && \
+    luarocks-5.3 install lpeg && \
+    luarocks-5.3 install lrexlib-pcre && \
+    luarocks-5.3 install luasec && \
+    luarocks-5.3 install luasocket && \
+    luarocks-5.3 install multipart-post
 
 COPY . /otouto
-
 WORKDIR /otouto
-
-RUN ./install-dependencies.sh
-
 CMD ./launch.sh
 

--- a/config.lua
+++ b/config.lua
@@ -2,9 +2,9 @@
 return {
 
     -- Your authorization token from the botfather. (string, put quotes)
-    bot_api_key = nil,
+    bot_api_key = os.getenv('OTOUTO_BOT_API_KEY'),
     -- Your Telegram ID (number).
-    admin = nil,
+    admin = os.getenv('ADMIN_ID'),
     -- Two-letter language code.
     -- Fetches it from the system if available, or defaults to English.
     lang = os.getenv('LANG') and os.getenv('LANG'):sub(1,2) or 'en',


### PR DESCRIPTION
I added a small Dockerfile that will grab the necessary dependencies to run the bot. I also turned the api key and admin id in config.lua into environment variables so they could be passed into the docker container at startup.

Example:
`docker run -e OTOUTO_BOT_API_KEY="apikeyhere" -e ADMIN_ID="idhere" jacobamason/otouto`