### PR TITLE
Add data_table for user & group and employ it

### DIFF
--- a/otouto/autils.lua
+++ b/otouto/autils.lua
@@ -6,7 +6,7 @@ local autils = {}
 function autils.rank(bot, user_id, chat_id)
     local user_id_str = tostring(user_id)
     user_id = tonumber(user_id)
-    local group = bot.database.administration.groups[tostring(chat_id)]
+    local group = bot.database.groupdata.admin[tostring(chat_id)]
 
     if user_id == bot.config.admin then
         return 5 -- Owner
@@ -133,10 +133,10 @@ function autils.strike(bot, msg, source)
         message_id = msg.message_id
     }
 
-    bot.database.administration.automoderation[tostring(msg.chat.id)] =
-        bot.database.administration.automoderation[tostring(msg.chat.id)] or {}
+    bot.database.groupdata.automoderation[tostring(msg.chat.id)] =
+        bot.database.groupdata.automoderation[tostring(msg.chat.id)] or {}
     local chat =
-        bot.database.administration.automoderation[tostring(msg.chat.id)]
+        bot.database.groupdata.automoderation[tostring(msg.chat.id)]
     local user_id_str = tostring(msg.from.id)
     chat[user_id_str] = (chat[user_id_str] or 0) + 1
 
@@ -225,7 +225,7 @@ function autils.log(bot, params)
     local log_chat = bot.config.administration.log_chat or bot.config.log_chat
     if params.chat_id then
         local group =
-            bot.database.administration.groups[tostring(params.chat_id)]
+            bot.database.groupdata.admin[tostring(params.chat_id)]
         output = output .. string.format(
             '<b>%s</b> <code>[%s]</code> <i>%s</i>\n',
             utilities.html_escape(group.name),

--- a/otouto/bot.lua
+++ b/otouto/bot.lua
@@ -47,11 +47,11 @@ function bot:init()
         self.database.userdata = { hammers = {}, administrators = {} }
     end
 
+    if not self.database.groupdata then
+        self.database.groupdata = { admin = {} }
+    end
     -- administration
-    -- database.groupdata when?
-    self.database.administration = self.database.administration or {
-        groups = {}
-    }
+    self.database.administration = self.database.administration or {}
 
     self.plugins = {}
     self.named_plugins = {}
@@ -111,15 +111,17 @@ function bot:on_message(msg)
     local user = {
         id_str = tostring(msg.from.id),
         rank = autils.rank(self, msg.from.id, msg.chat.id),
-        name = utilities.build_name(msg.from.first_name, msg.from.last_name)
+        name = utilities.build_name(msg.from.first_name, msg.from.last_name),
+        data = utilities.data_table(self.database.userdata, tostring(msg.from.id)),
     }
 
-    local group = self.database.administration and
-        self.database.administration.groups[tostring(msg.chat.id)]
+    local group = {
+        data = utilities.data_table(self.database.groupdata, tostring(msg.chat.id)),
+    }
 
     -- Do the thing.
     for _, plugin in ipairs(self.plugins) do
-        if (not plugin.administration or group) and user.rank >= (plugin.privilege or 0) then
+        if (not plugin.administration or group.data.admin) and user.rank >= (plugin.privilege or 0) then
             for _, trigger in ipairs(plugin.triggers) do
                 if string.match(msg.text_lower, trigger) then
 
@@ -159,14 +161,16 @@ function bot:on_edit(msg)
     local user = {
         id_str = tostring(msg.from.id),
         rank = autils.rank(self, msg.from.id, msg.chat.id),
-        name = utilities.build_name(msg.from.first_name, msg.from.last_name)
+        name = utilities.build_name(msg.from.first_name, msg.from.last_name),
+        data = utilities.data_table(self.database.userdata, tostring(msg.from.id)),
     }
 
-    local group = self.database.administration and
-        self.database.administration.groups[tostring(msg.chat.id)]
+    local group = {
+        data = utilities.data_table(self.database.groupdata, tostring(msg.chat.id)),
+    }
 
     for _, plugin in ipairs(self.plugins) do
-        if plugin.edit_action and (not plugin.administration or group) and user.rank >= (plugin.privilege or 0) then
+        if plugin.edit_action and (not plugin.administration or group.data.admin) and user.rank >= (plugin.privilege or 0) then
             for _, trigger in ipairs(plugin.triggers) do
                 if string.match(msg.text_lower, trigger) then
 

--- a/otouto/plugins/admin/addgroup.lua
+++ b/otouto/plugins/admin/addgroup.lua
@@ -39,11 +39,11 @@ function P:action(bot, msg, group)
             output =
                 'I must have permission to change group info, delete messages,'
                 .. ' and add, ban, and promote members.'
-        elseif group then
+        elseif group.data.admin then
             output = 'I am already administrating this group.'
         else
             local chat_id_str = tostring(msg.chat.id)
-            bot.database.administration.groups[chat_id_str] = {
+            group.data.admin = {
                 name = msg.chat.title,
                 link =
                     bindings.exportChatInviteLink{chat_id = msg.chat.id}.result,

--- a/otouto/plugins/admin/addmod.lua
+++ b/otouto/plugins/admin/addmod.lua
@@ -30,11 +30,12 @@ function P:action(bot, msg, group)
                         ' is greater than a moderator.')
                 else
                     autils.promote_admin(msg.chat.id, id)
-                    if group.moderators[id_str] then
+                    local admin = group.data.admin
+                    if admin.moderators[id_str] then
                         table.insert(output, name .. ' is already a moderator.')
                     else
-                        group.moderators[id_str] = true
-                        group.bans[id_str] = nil
+                        admin.moderators[id_str] = true
+                        admin.bans[id_str] = nil
                         table.insert(output, name .. ' is now a moderator.')
                     end
                 end

--- a/otouto/plugins/admin/antibot.lua
+++ b/otouto/plugins/admin/antibot.lua
@@ -15,7 +15,7 @@ end
 
 function P:action(bot, msg, group, user)
     if
-        group.flags[self.flag] and
+        group.data.admin.flags[self.flag] and
         msg.new_chat_member and
         msg.new_chat_member.is_bot and
         user.rank < 2

--- a/otouto/plugins/admin/antihammer_whitelist.lua
+++ b/otouto/plugins/admin/antihammer_whitelist.lua
@@ -16,6 +16,7 @@ end
 
 function P:action(bot, msg, group)
     local targets = autils.targets(bot, msg)
+    local admin = group.data.admin
     local output = {}
 
     if targets then
@@ -23,12 +24,12 @@ function P:action(bot, msg, group)
             if tonumber(id) then
                 local id_str = tostring(id)
                 local name = utilities.format_name(bot, id)
-                if group.antihammer[id_str] then
-                    group.antihammer[id_str] = nil
+                if admin.antihammer[id_str] then
+                    admin.antihammer[id_str] = nil
                     table.insert(output, name ..
                         ' has been removed from the antihammer whitelist.')
                 else
-                    group.antihammer[id_str] = true
+                    admin.antihammer[id_str] = true
                     table.insert(output, name ..
                         ' has been added to the antihammer whitelist.')
                 end
@@ -37,9 +38,9 @@ function P:action(bot, msg, group)
             end
         end
 
-    elseif next(group.antihammer) ~= nil then
+    elseif next(admin.antihammer) ~= nil then
         table.insert(output, '<b>Antihammered users:</b>')
-        for id in pairs(group.antihammer) do
+        for id in pairs(admin.antihammer) do
             table.insert(output, '• ' .. utilities.format_name(bot, id))
         end
 

--- a/otouto/plugins/admin/antisquig.lua
+++ b/otouto/plugins/admin/antisquig.lua
@@ -18,7 +18,7 @@ function P:init(bot)
 end
 
 function P:action(bot, msg, group, user)
-    if not group.flags[self.flag] then return true end
+    if not group.data.admin.flags[self.flag] then return true end
     if user.rank > 1 then return true end
     if msg.forward_from and (
         msg.forward_from.id == bot.info.id or

--- a/otouto/plugins/admin/antisquigpp.lua
+++ b/otouto/plugins/admin/antisquigpp.lua
@@ -15,7 +15,7 @@ function P:init(bot)
 end
 
 function P:action(bot, msg, group, user)
-    if not group.flags[self.flag] then return true end
+    if not group.data.admin.flags[self.flag] then return true end
     if user.rank > 1 then return true end
     if user.name:match(utilities.char.arabic) or
         user.name:match(utilities.char.rtl_override) or

--- a/otouto/plugins/admin/automoderation.lua
+++ b/otouto/plugins/admin/automoderation.lua
@@ -12,8 +12,8 @@ local bindings = require('otouto.bindings')
 local P = {}
 
 function P:init(bot)
-    bot.database.administration.automoderation =
-        bot.database.administration.automoderation or {}
+    bot.database.groupdata.automoderation =
+        bot.database.groupdata.automoderation or {}
     bot.database.administration.automod_timer =
         bot.database.administration.automod_timer or os.date('%d')
 
@@ -35,7 +35,7 @@ end
 
 function P:cron(bot, _now)
     if bot.database.administration.automod_timer ~= os.date('%d') then
-        bot.database.administration.automoderation = {}
+        bot.database.groupdata.automoderation = {}
         bot.database.administration.automod_timer = os.date('%d')
     end
 

--- a/otouto/plugins/admin/ban.lua
+++ b/otouto/plugins/admin/ban.lua
@@ -27,12 +27,13 @@ function P:action(bot, msg, group)
         for _, id in ipairs(targets) do
             if tonumber(id) then
                 local name = utilities.format_name(bot, id)
+                local admin = group.data.admin
                 if autils.rank(bot, id, msg.chat.id) > 2 then
                     table.insert(output, name .. ' is too privileged to be banned.')
-                elseif group.bans[tostring(id)] then
+                elseif admin.bans[tostring(id)] then
                     table.insert(output, name .. ' is already banned.')
                 else
-                    group.bans[tostring(id)] = true
+                    admin.bans[tostring(id)] = true
                     bindings.kickChatMember{
                         chat_id = msg.chat.id,
                         user_id = id

--- a/otouto/plugins/admin/deadmin.lua
+++ b/otouto/plugins/admin/deadmin.lua
@@ -22,7 +22,7 @@ function P:action(bot, msg, _group, _user)
                 if bot.database.userdata.administrators[tostring(id)] then
                     bot.database.userdata.administrators[tostring(id)] =
                         nil
-                    for chat_id in pairs(bot.database.administration.groups) do
+                    for chat_id in pairs(bot.database.groupdata.admin) do
                         if autils.rank(bot, id, chat_id) < 2 then
                             autils.demote_admin(chat_id, id)
                         end

--- a/otouto/plugins/admin/demod.lua
+++ b/otouto/plugins/admin/demod.lua
@@ -25,11 +25,12 @@ function P:action(bot, msg, group)
             else
                 local id_str = tostring(id)
                 local name = utilities.format_name(bot, id)
+                local admin = group.data.admin
                 if autils.rank(bot, id, msg.chat.id) < 3 then
                     autils.demote_admin(msg.chat.id, id)
                 end
-                if group.moderators[id_str] then
-                    group.moderators[id_str] = nil
+                if admin.moderators[id_str] then
+                    admin.moderators[id_str] = nil
                     table.insert(output, name .. ' is no longer a moderator.')
                 else
                     table.insert(output, name .. ' is not a moderator.')

--- a/otouto/plugins/admin/filter.lua
+++ b/otouto/plugins/admin/filter.lua
@@ -13,28 +13,29 @@ function P:init(bot)
 end
 
 function P:action(_bot, msg, group, _user)
+    local admin = group.data.admin
     local input = utilities.input(msg.text_lower)
     local output
     if input then
         local idx
-        for i = 1, #group.filter do
-            if group.filter[i] == input then
+        for i = 1, #admin.filter do
+            if admin.filter[i] == input then
                 idx = i
                 break
             end
         end
         if idx then
-            table.remove(group.filter, idx)
+            table.remove(admin.filter, idx)
             output = 'That term has been removed from the filter.'
         else
-            table.insert(group.filter, input)
+            table.insert(admin.filter, input)
             output = 'That term has been added to the filter.'
         end
-    elseif #group.filter == 0 then
+    elseif #admin.filter == 0 then
         output = 'There are currently no filtered terms.'
     else
         output = '<b>Filtered terms:</b>\n• ' ..
-            utilities.html_escape(table.concat(group.filter, '\n• '))
+            utilities.html_escape(table.concat(admin.filter, '\n• '))
     end
     utilities.send_reply(msg, output, 'html')
 end

--- a/otouto/plugins/admin/filterer.lua
+++ b/otouto/plugins/admin/filterer.lua
@@ -19,8 +19,9 @@ function P:action(bot, msg, group, user)
     ) then
         return true
     end
-    for i = 1, #group.filter do
-        if msg.text_lower:match(group.filter[i]) then
+    local admin = group.data.admin
+    for i = 1, #admin.filter do
+        if msg.text_lower:match(admin.filter[i]) then
             bindings.deleteMessage{
                 message_id = msg.message_id,
                 chat_id = msg.chat.id
@@ -30,7 +31,7 @@ function P:action(bot, msg, group, user)
                 target = msg.from.id,
                 action = 'Message deleted',
                 source = self.name,
-                reason = utilities.html_escape(rot13.cipher(group.filter[i]))
+                reason = utilities.html_escape(rot13.cipher(admin.filter[i]))
             })
             return
         end

--- a/otouto/plugins/admin/flags.lua
+++ b/otouto/plugins/admin/flags.lua
@@ -29,6 +29,7 @@ table.concat(default_flags, '\n•')
 end
 
 function P:action(_bot, msg, group)
+    local admin = group.data.admin
     local input = utilities.input_from_msg(msg)
     local output = {}
 
@@ -36,11 +37,11 @@ function P:action(_bot, msg, group)
         for word in input:gmatch('%g+') do
             local word_lwr = word:lower()
             if self.flags[word_lwr] then
-                if group.flags[word_lwr] then
-                    group.flags[word_lwr] = nil
+                if admin.flags[word_lwr] then
+                    admin.flags[word_lwr] = nil
                     table.insert(output, word .. ' has been disabled.')
                 else
-                    group.flags[word_lwr] = true
+                    admin.flags[word_lwr] = true
                     table.insert(output, word .. ' has been enabled.')
                 end
             else
@@ -53,7 +54,7 @@ function P:action(_bot, msg, group)
         table.insert(output, '<b>Flags:</b>')
         for name, desc in pairs(self.flags) do
             table.insert(output, string.format('%s <b>%s</b>\n%s',
-                group.flags[name] and '✔️' or '❌',
+                admin.flags[name] and '✔️' or '❌',
                 name,
                 desc
             ))

--- a/otouto/plugins/admin/getdescription.lua
+++ b/otouto/plugins/admin/getdescription.lua
@@ -12,7 +12,7 @@ function P:action(bot, msg, group)
     local input = utilities.input(msg.text_lower)
     local chat_id
     if input then
-        for id_str, chat in pairs(bot.database.administration.groups) do
+        for id_str, chat in pairs(bot.database.groupdata.admin) do
             if not chat.flags.private and chat.name:lower():match(input) then
                 chat_id = id_str
                 break
@@ -22,7 +22,7 @@ function P:action(bot, msg, group)
             utilities.send_reply(msg, 'Group not found.')
             return
         end
-    elseif group then
+    elseif group.data.admin then
         chat_id = msg.chat.id
     else
         utilities.send_reply(msg, 'Specify a group.')
@@ -43,42 +43,42 @@ function P:action(bot, msg, group)
 end
 
 function P:desc(bot, chat_id)
-    local group = bot.database.administration.groups[tostring(chat_id)]
+    local admin = bot.database.groupdata.admin[tostring(chat_id)]
 
     local output = '<b>Welcome to '
-    if group.flags.private then
-        output = output .. utilities.html_escape(group.name) .. '!</b>'
+    if admin.flags.private then
+        output = output .. utilities.html_escape(admin.name) .. '!</b>'
     else
-        output = output .. '</b><a href="' .. group.link .. '">' ..
-            utilities.html_escape(group.name) .. '</a><b>!</b>'
+        output = output .. '</b><a href="' .. admin.link .. '">' ..
+            utilities.html_escape(admin.name) .. '</a><b>!</b>'
     end
 
     output = output ..' <code>['.. utilities.normalize_id(chat_id) .. ']</code>'
 
-    if group.description then
-        output = output .. '\n\n' .. group.description
+    if admin.description then
+        output = output .. '\n\n' .. admin.description
     end
 
-    if #group.rules > 0 then
+    if #admin.rules > 0 then
         output = output .. '\n\n<b>Rules:</b>'
-        for i, rule in ipairs(group.rules) do
+        for i, rule in ipairs(admin.rules) do
             output = output .. '\n<b>' .. i .. '.</b> ' .. rule
         end
     end
 
-    if next(group.flags) ~= nil then
+    if next(admin.flags) ~= nil then
         output = output .. '\n\n<b>Flags:</b>'
-        for flag in pairs(group.flags) do
+        for flag in pairs(admin.flags) do
             output = output .. '\n• ' .. bot.named_plugins['admin.flags'].flags[flag]
         end
     end
 
     output = output .. '\n\n<b>Governor:</b> ' ..
-        utilities.format_name(bot, group.governor)
+        utilities.format_name(bot, admin.governor)
 
-    if next(group.moderators) ~= nil then
+    if next(admin.moderators) ~= nil then
         output = output .. '\n\n<b>Moderators:</b>'
-        for id in pairs(group.moderators) do
+        for id in pairs(admin.moderators) do
             output = output .. '\n• ' .. utilities.format_name(bot, id)
         end
     end

--- a/otouto/plugins/admin/getlink.lua
+++ b/otouto/plugins/admin/getlink.lua
@@ -12,15 +12,16 @@ function P:init(bot)
 end
 
 function P:action(_bot, msg, group, user)
+    local admin = group.data.admin
     local output
     local link = string.format(
         '<a href="%s">%s</a>',
-        group.link,
+        admin.link,
         utilities.html_escape(msg.chat.title)
     )
 
     -- Links to private groups are mods+ and are only PM'd.
-    if group.flags.private then
+    if admin.flags.private then
         if user.rank > 1 then
             if utilities.send_message(msg.from.id, link, true, nil, 'html') then
                 output = 'I have sent you the requested information in a private message.'

--- a/otouto/plugins/admin/groupinfo.lua
+++ b/otouto/plugins/admin/groupinfo.lua
@@ -12,9 +12,10 @@ function P:init(_bot)
 end
 
 function P:action(bot, msg, group)
-    group.username = msg.chat.username
+    local admin = group.data.admin
+    admin.username = msg.chat.username
     -- Log when the chat title has been changed.
-    if msg.chat.title ~= group.name then
+    if msg.chat.title ~= admin.name then
         autils.log(bot, {
             chat_id = msg.chat.id,
             action = 'Title changed',
@@ -23,7 +24,7 @@ function P:action(bot, msg, group)
             -- notice the name change), the source will be unknown.
             source_id = msg.new_chat_title and msg.from.id or nil
         })
-        group.name = msg.chat.title
+        admin.name = msg.chat.title
     end
     return true
 end

--- a/otouto/plugins/admin/hammer.lua
+++ b/otouto/plugins/admin/hammer.lua
@@ -50,9 +50,10 @@ function P:action(bot, msg, group)
 
     utilities.send_reply(msg, table.concat(output, '\n'), 'html')
     if #hammered_users > 0 then
+        local admin = group.data.admin
         autils.log(bot, {
             -- Do not send the chat ID from PMs or private groups.
-            chat_id = group and (not group.flags.private) and msg.chat.id,
+            chat_id = admin and (not admin.flags.private) and msg.chat.id,
             targets = hammered_users,
             action = 'Globally banned',
             source_id = msg.from.id,

--- a/otouto/plugins/admin/listgroups.lua
+++ b/otouto/plugins/admin/listgroups.lua
@@ -18,7 +18,7 @@ function P:action(bot, msg, group)
     local results = {}
     local listed_groups = {}
 
-    for _, chat in pairs(bot.database.administration.groups) do
+    for _, chat in pairs(bot.database.groupdata.admin) do
         if not chat.flags.private then
             local link = string.format('<a href="%s">%s</a>',
                 chat.link,
@@ -49,7 +49,7 @@ function P:action(bot, msg, group)
             '<b>Groups:</b>\n• ' .. table.concat(listed_groups, '\n• ')
         if #listed_groups == 0 then
             output = 'There are no listed groups.'
-        elseif group then
+        elseif group.data.admin then
             if utilities.send_message(msg.from.id, group_list, true, nil, 'html') then
                 output = 'I have sent you the requested information in a private message.'
             else

--- a/otouto/plugins/admin/listmods.lua
+++ b/otouto/plugins/admin/listmods.lua
@@ -11,11 +11,12 @@ function P:init(bot)
 end
 
 function P:action(bot, msg, group)
+    local admin = group.data.admin
     local output = '<b>Governor:</b> ' ..
-        utilities.format_name(bot, group.governor)
-    if next(group.moderators) ~= nil then
+        utilities.format_name(bot, admin.governor)
+    if next(admin.moderators) ~= nil then
         local mod_list = {}
-        for id_str in pairs(group.moderators) do
+        for id_str in pairs(admin.moderators) do
             table.insert(mod_list, utilities.format_name(bot, id_str))
         end
         output = output ..  '\n\n<b>Moderators:</b>\n• ' ..

--- a/otouto/plugins/admin/listrules.lua
+++ b/otouto/plugins/admin/listrules.lua
@@ -11,21 +11,22 @@ function P:init(bot)
 end
 
 function P:action(bot, msg, group)
+    local admin = group.data.admin
     local input = tonumber(utilities.get_word(msg.text, 2))
     local output
-    if #group.rules == 0 then
+    if #admin.rules == 0 then
         output = 'No rules have been set for this group.'
-    elseif input and group.rules[input] then
-        output = '<b>' .. input .. '.</b> ' .. group.rules[input]
+    elseif input and admin.rules[input] then
+        output = '<b>' .. input .. '.</b> ' .. admin.rules[input]
     else
-        output = '<b>Rules for ' ..utilities.html_escape(group.name).. ':</b>'
-        for i, rule in ipairs(group.rules) do
+        output = '<b>Rules for ' ..utilities.html_escape(admin.name).. ':</b>'
+        for i, rule in ipairs(admin.rules) do
             output = output .. '\n<b>' .. i .. '</b>. ' .. rule
         end
 
-        if next(group.flags) ~= nil then
+        if next(admin.flags) ~= nil then
             output = output .. '\n\n<b>Flags:</b>'
-            for flag in pairs(group.flags) do
+            for flag in pairs(admin.flags) do
                 output = output .. '\n• ' .. flag .. ': ' ..
                     bot.named_plugins['admin.flags'].flags[flag]
             end

--- a/otouto/plugins/admin/nostickers.lua
+++ b/otouto/plugins/admin/nostickers.lua
@@ -14,7 +14,7 @@ function P:init(bot)
 end
 
 function P:action(bot, msg, group, _user)
-    if group.flags[self.flag] and msg.sticker then
+    if group.data.admin.flags[self.flag] and msg.sticker then
         bindings.deleteMessage{
             message_id = msg.message_id,
             chat_id = msg.chat.id

--- a/otouto/plugins/admin/regenlink.lua
+++ b/otouto/plugins/admin/regenlink.lua
@@ -13,7 +13,7 @@ function P:init(bot)
 end
 
 function P:action(_bot, msg, group)
-    group.link = bindings.exportChatInviteLink{
+    group.data.admin.link = bindings.exportChatInviteLink{
         chat_id = msg.chat.id
     }.result
     utilities.send_reply(msg, 'The link has been regenerated.')

--- a/otouto/plugins/admin/removegroup.lua
+++ b/otouto/plugins/admin/removegroup.lua
@@ -18,14 +18,13 @@ function P:action(bot, msg, group)
     if input then
         local id = tostring(tonumber(input))
         if id then
-            if bot.database.administration.groups[id] then
-                output = 'I am no longer administrating ' ..
-                    bot.database.administration.groups[id].name .. '.'
-                bot.database.administration.groups[id] = nil
-            elseif bot.database.administration.groups['-100'..id] then
-                output = 'I am no longer administrating ' ..
-                    bot.database.administration.groups['-100'..id].name .. '.'
-                bot.database.administration.groups['-100'..id] = nil
+            local admin = bot.database.groupdata.admin
+            if admin[id] then
+                output = 'I am no longer administrating ' ..  admin[id].name .. '.'
+                admin[id] = nil
+            elseif admin['-100'..id] then
+                output = 'I am no longer administrating ' ..  admin['-100'..id].name .. '.'
+                admin['-100'..id] = nil
             else
                 output = 'Group not found (' .. id .. ').'
             end
@@ -34,9 +33,10 @@ function P:action(bot, msg, group)
         end
 
     else
-        if group then
+        local admin = group.data.admin
+        if admin then
             output = 'I am no longer administrating ' .. msg.chat.title .. '.'
-            bot.database.administration.groups[tostring(msg.chat.id)] = nil
+            group.data.admin = nil
         else
             output = 'Run in an administrated group or pass one\'s ID.'
         end

--- a/otouto/plugins/admin/setdescription.lua
+++ b/otouto/plugins/admin/setdescription.lua
@@ -11,21 +11,22 @@ function P:init(bot)
 end
 
 function P:action(_bot, msg, group)
+    local admin = group.data.admin
     local input = utilities.input_from_msg(msg)
     if not input then
-        if group.description then
+        if admin.description then
             utilities.send_reply(msg, '</b>Current description:</b>\n' ..
-                group.description, 'html')
+                admin.description, 'html')
         else
             utilities.send_reply(msg, 'This group has no description.')
         end
     elseif input == '--' or input == utilities.char.em_dash then
-        group.description = nil
+        admin.description = nil
         utilities.send_reply(msg, 'The group description has been cleared.')
     else
-        group.description = input
+        admin.description = input
         utilities.send_reply(msg, '<b>Description updated:</b>\n' ..
-            group.description, 'html')
+            admin.description, 'html')
     end
 end
 

--- a/otouto/plugins/admin/setgovernor.lua
+++ b/otouto/plugins/admin/setgovernor.lua
@@ -17,19 +17,20 @@ function P:action(bot, msg, group)
     local target = targets and targets[1]
     local output
     if tonumber(target) then
+        local admin = group.data.admin
         local name = utilities.format_name(bot, target)
         autils.promote_admin(msg.chat.id, target, true)
-        if target == group.governor then
+        if target == admin.governor then
             output = name .. ' is already governor.'
         else
             -- Demote the old governor if he's not an admin.
-            if autils.rank(bot, group.governor, msg.chat.id) < 4 then
-                autils.demote_admin(msg.chat.id, group.governor)
+            if autils.rank(bot, admin.governor, msg.chat.id) < 4 then
+                autils.demote_admin(msg.chat.id, admin.governor)
             end
 
-            group.moderators[tostring(target)] = nil
-            group.bans[tostring(target)] = nil
-            group.governor = target
+            admin.moderators[tostring(target)] = nil
+            admin.bans[tostring(target)] = nil
+            admin.governor = target
             output = name .. ' is now governor.'
         end
     elseif not target then

--- a/otouto/plugins/admin/setrules.lua
+++ b/otouto/plugins/admin/setrules.lua
@@ -86,14 +86,15 @@ end
 
 P.subcommands = {
     change = function (super, group, new_rules, idx)
+        local admin = group.data.admin
         if #new_rules == 0 then
             return 'Please specify the new rule or rules.'
 
         elseif not idx then -- /setrules
-            group.rules = new_rules
-            local output = '<b>Rules for ' .. utilities.html_escape(group.name) ..
+            admin.rules = new_rules
+            local output = '<b>Rules for ' .. utilities.html_escape(admin.name) ..
                 ':</b>'
-            for i, rule in ipairs(group.rules) do
+            for i, rule in ipairs(admin.rules) do
                 output = output .. '\n<b>' .. i .. '.</b> ' .. rule
             end
             return output
@@ -101,13 +102,13 @@ P.subcommands = {
         elseif idx < 1 then
             return 'Invalid index.'
 
-        elseif idx > #group.rules then
+        elseif idx > #admin.rules then
             return super.subcommands.add(group, new_rules, idx)
 
         else -- /changerule i
             local output = ''
             for i = 1, #new_rules do
-                group.rules[idx+i-1] = new_rules[i]
+                admin.rules[idx+i-1] = new_rules[i]
                 output = output .. '\n<b>' .. idx+i-1 .. '.</b> ' .. new_rules[i]
             end
             return output
@@ -115,14 +116,15 @@ P.subcommands = {
     end,
 
     add = function (_super, group, new_rules, idx)
+        local admin = group.data.admin
         if #new_rules == 0 then
             return 'Please specify the new rule or rules.'
 
-        elseif not idx or idx > #group.rules then -- /addrule
+        elseif not idx or idx > #admin.rules then -- /addrule
             local output = ''
             for i = 1, #new_rules do
-                table.insert(group.rules, new_rules[i])
-                output = output .. '\n<b>' .. #group.rules .. '.</b> ' .. new_rules[i]
+                table.insert(admin.rules, new_rules[i])
+                output = output .. '\n<b>' .. #admin.rules .. '.</b> ' .. new_rules[i]
             end
             return output
 
@@ -132,7 +134,7 @@ P.subcommands = {
         else -- /addrule i
             local output = ''
             for i = 1, #new_rules do
-                table.insert(group.rules, idx+i-1, new_rules[i])
+                table.insert(admin.rules, idx+i-1, new_rules[i])
                 output = output .. '\n<b>' .. idx+i-1 .. '.</b> ' .. new_rules[i]
             end
             return output
@@ -140,15 +142,16 @@ P.subcommands = {
     end,
 
     del = function (_super, group, _new_rules, idx)
+        local admin = group.data.admin
         if not idx then -- /setrules --
-            group.rules = {}
+            admin.rules = {}
             return 'The rules have been deleted.'
 
-        elseif idx > #group.rules or idx < 0 then
+        elseif idx > #admin.rules or idx < 0 then
             return 'Invalid index.'
 
         else -- /changerule i --
-            table.remove(group.rules, idx)
+            table.remove(admin.rules, idx)
             return 'Rule ' .. idx .. ' has been deleted.'
         end
     end,

--- a/otouto/plugins/admin/unrestrict.lua
+++ b/otouto/plugins/admin/unrestrict.lua
@@ -27,11 +27,13 @@ function P:action(bot, msg, group)
                     can_send_other_messages = true,
                     can_add_web_page_previews = true
                 }
-                if bot.database.administration.automoderation[tostring(msg.chat.id)] then
-                    bot.database.administration.automoderation[tostring(msg.chat.id)][tostring(id)] = nil
+                local automoderation = group.data.automoderation
+                if automoderation then
+                    automoderation[tostring(id)] = nil
                 end
-                if group.bans[tostring(id)] then
-                    group.bans[tostring(id)] = nil
+                local admin = group.data.admin
+                if admin.bans[tostring(id)] then
+                    admin.bans[tostring(id)] = nil
                     table.insert(output, utilities.format_name(bot, id) ..
                         ' has been unbanned and unrestricted.')
                 elseif bot.database.userdata.hammers[tostring(id)] then

--- a/otouto/plugins/core/luarun.lua
+++ b/otouto/plugins/core/luarun.lua
@@ -21,7 +21,7 @@ function luarun:init(bot)
     end
 end
 
-function luarun:action(bot, msg, group)
+function luarun:action(bot, msg, ...)
     if msg.from.id ~= bot.config.admin then
         return true
     end
@@ -46,13 +46,13 @@ function luarun:action(bot, msg, group)
         local lume = require('lume')\n\z
         local serpent = require('serpent')\n\z
         local url = require('socket.url')\n\z
-        return function (bot, msg, group)\n" .. input .. "\nend"
+        return function (bot, msg, group, user)\n" .. input .. "\nend"
     )
 
     if output == nil then
         output = success
     else
-        _, output = xpcall(output(), self.err_msg, bot, msg, group)
+        _, output = xpcall(output(), self.err_msg, bot, msg, ...)
     end
 
     if output == nil then

--- a/otouto/utilities.lua
+++ b/otouto/utilities.lua
@@ -145,6 +145,36 @@ function utilities.table_size(tab)
     return i
 end
 
+utilities.data_table_meta = {
+    __index = function (self, key)
+        if rawget(self, "_data")._parent then
+            local val = rawget(self, "_data")[key]
+            return val and
+                setmetatable({_data = val, _key = rawget(self, "_key")}, getmetatable(self))
+        else
+            local val = rawget(self, "_data")[key]
+            return val and val[rawget(self, "_key")]
+        end
+    end,
+    __newindex = function (self, key, value)
+        if rawget(self, "_data")._parent then
+            error("Can't set non-terminal key " .. tostring(key) .. " in a data_table")
+            return
+        else
+            local t = rawget(self, "_data")[key]
+            if t == nil then
+                t = {}
+                rawget(self, "_data")[key] = t
+            end
+            t[rawget(self, "_key")] = value
+            return
+        end
+    end
+}
+function utilities.data_table(data, key)
+    return setmetatable({_data = data, _key = key}, utilities.data_table_meta)
+end
+
 -- Just an easy way to get a user's full name.
 -- Alternatively, abuse it to concat two strings like I do.
 function utilities.build_name(first, last)
@@ -236,13 +266,14 @@ utilities.triggers_meta = {
         return self
     end
 }
+utilities.triggers_meta.__index = utilities.triggers_meta
 
 function utilities.triggers(username, cmd_pat, trigger_table)
     return setmetatable({
         username = username,
         cmd_pat = cmd_pat,
         table = trigger_table or {}
-    }, {__index = utilities.triggers_meta})
+    }, utilities.triggers_meta)
 end
 
 function utilities.pretty_float(x)
@@ -293,8 +324,9 @@ utilities.set_meta = {
         return self.__count
     end
 }
+utilities.set_meta.__index = utilities.set_meta
 function utilities.new_set()
-    return setmetatable({__count = 0}, {__index = utilities.set_meta})
+    return setmetatable({__count = 0}, utilities.set_meta)
 end
 
 -- Converts a gross string back into proper UTF-8.


### PR DESCRIPTION
Finishes moving stuff to `userdata` and makes `groupdata` for group info (moving `database.administration.groups` to `database.groupdata.admin`).

This breaks database compatibility in a couple of places, does not provide a migration, and has not been tested because it's 2:00 in the morning and I'm heading off to bed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/topkecleon/otouto/110)
<!-- Reviewable:end -->
